### PR TITLE
Fix bug in parametric match of boundary pivots

### DIFF
--- a/src/tsim/external/pyzx/rules.py
+++ b/src/tsim/external/pyzx/rules.py
@@ -465,7 +465,7 @@ def match_pivot_boundary(
         if not good_vert or w is None: continue
         if bound in inputs: mod = 0.5
         else: mod = -0.5
-        v1 = g.add_vertex(VertexType.Z,-2,rs[w]+mod,phases[w])
+        v1 = g.add_vertex(VertexType.Z,-2,rs[w]+mod,phases[w], phaseVars=g.get_params(w))
         v2 = g.add_vertex(VertexType.Z,-1,rs[w]+mod,0)
         g.set_phase(w, 0)
         g.update_phase_index(w,v1)


### PR DESCRIPTION
A minimum reproducible example is

<img width="138" height="61" alt="image" src="https://github.com/user-attachments/assets/b4afdd8a-5cae-4955-9053-5a2727773fd1" />

Before this PR, zx reduction using `zx.simplify.pivot_boundary_simp(g)` would result in a wrong additional phase of -1.

A PR with detailed unit tests will follow.