### PR TITLE
Replace vmap with explict batch dimension and use BLAS matmul

### DIFF
--- a/src/tsim/compile/evaluate.py
+++ b/src/tsim/compile/evaluate.py
@@ -31,61 +31,51 @@ _ONE_PLUS_PHASES = _UNIT_PHASES.at[:, 0].add(1)
 _IDENTITY = jnp.array([1, 0, 0, 0], dtype=jnp.int32)
 
 
-@overload
-def evaluate(
-    circuit: CompiledScalarGraphs,
-    param_vals: Array,
-    has_approximate_floatfactor: Literal[False],
-) -> ExactScalarArray: ...
+def _matmul_gf2(a: Array, b: Array) -> Array:
+    """Compute binary dot products mod 2 as ``a_GTP x b_BP -> b_BGT``.
+
+    Uses float32 matmul (integer matmul does not have BLAS support on CPU)
+    then casts back to uint8.
+
+    Args:
+        a: Parameter bit-masks, shape ``(G, T, P)`` — G graphs, T terms, P parameters.
+        b: Binary parameter values, shape ``(B, P)`` — B batch elements.
+
+    Returns:
+        Binary row-sums mod 2, shape ``(B, G, T)``.
+
+    """
+    G, T, _ = a.shape
+    if G * T == 0:
+        return jnp.zeros((b.shape[0], G, T), dtype=b.dtype)
+    return (b.astype(jnp.float32) @ a.astype(jnp.float32).reshape(G * T, -1).T).reshape(
+        -1, G, T
+    ).astype(jnp.uint8) % 2
 
 
-@overload
-def evaluate(
-    circuit: CompiledScalarGraphs,
-    param_vals: Array,
-    has_approximate_floatfactor: Literal[True],
-) -> Array: ...
-
-
-@overload
-def evaluate(
-    circuit: CompiledScalarGraphs,
-    param_vals: Array,
-    has_approximate_floatfactor: bool,
-) -> ExactScalarArray | Array: ...
-
-
-@functools.partial(jax.jit, static_argnums=(2,))
-def evaluate(
-    circuit: CompiledScalarGraphs, param_vals: Array, has_approximate_floatfactor: bool
-) -> ExactScalarArray | Array:
-    """Evaluate compiled circuit with parameter values.
+@jax.jit
+def evaluate(circuit: CompiledScalarGraphs, param_vals: Array) -> Array:
+    """Evaluate compiled circuit with batched parameter values.
 
     Args:
         circuit: Compiled circuit representation
         param_vals: Binary parameter values (error bits + measurement/detector outcomes),
-            shape (n_params,)
-        has_approximate_floatfactor: Whether the circuit has approximate float factors.
-            Determines the return type and evaluation strategy.
+            shape (batch_size, n_params)
 
     Returns:
-        ExactScalarArray if has_approximate_floatfactor is False, otherwise a complex Array
-        representing the amplitude for the given parameter configuration.
+        A complex array of shape (batch_size,) containing the amplitudes of the provided
+        circuit evaluated with the given binary parameter values.
 
     """
-    num_graphs = circuit.power2.shape[0]
-
     # ====================================================================
     # TYPE A: Node Terms (1 + e^(i*alpha))
-    # Shape: (num_graphs, max_a) -> (num_graphs, max_a, 4) -> prod -> (num_graphs, 4)
     # Padded values are masked to multiplicative identity.
     # ====================================================================
-    # a_param_bits: (num_graphs, max_a, n_params), param_vals: (n_params,)
-    # Broadcast: (num_graphs, max_a, n_params) * (n_params,) -> sum over last axis
-    rowsum_a = jnp.sum(circuit.a_param_bits * param_vals, axis=-1) % 2
+    # a_param_bits: (num_graphs, max_a, n_params), param_vals: (batch_size, n_params,)
+    rowsum_a = _matmul_gf2(circuit.a_param_bits, param_vals)
     phase_idx_a = (4 * rowsum_a + circuit.a_const_phases) % 8
 
-    term_vals_a_exact = _ONE_PLUS_PHASES[phase_idx_a]  # (num_graphs, max_a, 4)
+    term_vals_a_exact = _ONE_PLUS_PHASES[phase_idx_a]
     a_mask = (
         jnp.arange(circuit.a_const_phases.shape[1])[None, :]
         < circuit.a_num_terms[:, None]
@@ -93,54 +83,49 @@ def evaluate(
     term_vals_a_exact = jnp.where(a_mask[..., None], term_vals_a_exact, _IDENTITY)
 
     term_vals_a = ExactScalarArray(term_vals_a_exact)
-    summands_a = term_vals_a.prod(axis=1)  # (num_graphs, 4)
+    summands_a = term_vals_a.prod(axis=-2)
 
     # ====================================================================
     # TYPE B: Half-Pi Terms (e^(i*beta))
-    # For Type B (monomials), we can sum indices modulo 8 instead of multiplying scalars
     # Padded values are 0, so they don't affect the sum.
     # ====================================================================
-    rowsum_b = jnp.sum(circuit.b_param_bits * param_vals, axis=-1) % 2
-    phase_idx_b = (rowsum_b * circuit.b_term_types) % 8  # (num_graphs, max_b)
+    rowsum_b = _matmul_gf2(circuit.b_param_bits, param_vals)
+    phase_idx_b = (rowsum_b * circuit.b_term_types) % 8
 
-    sum_phases_b = jnp.sum(phase_idx_b, axis=1) % 8  # (num_graphs,)
+    sum_phases_b = jnp.sum(phase_idx_b, axis=-1) % 8
 
-    # Convert final summed phase to ExactScalar
-    summands_b_exact = _UNIT_PHASES[sum_phases_b]  # (num_graphs, 4)
+    summands_b_exact = _UNIT_PHASES[sum_phases_b]
     summands_b = ExactScalarArray(summands_b_exact)
 
     # ====================================================================
     # TYPE C: Pi-Pair Terms, (-1)^(Psi*Phi)
-    # These are +/- 1. Padded values contribute 0 to the exponent sum.
     # ====================================================================
     rowsum_a_c = (
-        circuit.c_const_bits_a + jnp.sum(circuit.c_param_bits_a * param_vals, axis=-1)
+        circuit.c_const_bits_a + _matmul_gf2(circuit.c_param_bits_a, param_vals)
     ) % 2
     rowsum_b_c = (
-        circuit.c_const_bits_b + jnp.sum(circuit.c_param_bits_b * param_vals, axis=-1)
+        circuit.c_const_bits_b + _matmul_gf2(circuit.c_param_bits_b, param_vals)
     ) % 2
 
-    exponent_c = (rowsum_a_c * rowsum_b_c) % 2  # (num_graphs, max_c)
+    exponent_c = (rowsum_a_c * rowsum_b_c) % 2
+    sum_exponents_c = jnp.sum(exponent_c, axis=-1) % 2
 
-    sum_exponents_c = jnp.sum(exponent_c, axis=1) % 2  # (num_graphs,)
-
-    # Map 0 -> 1, 1 -> -1
-    summands_c_exact = jnp.zeros((num_graphs, 4), dtype=jnp.int32)
-    summands_c_exact = summands_c_exact.at[:, 0].set(1 - 2 * sum_exponents_c)
+    summands_c_exact = (1 - 2 * sum_exponents_c)[..., None] * jnp.array(
+        [1, 0, 0, 0], dtype=jnp.int32
+    )
     summands_c = ExactScalarArray(summands_c_exact)
 
     # ====================================================================
     # TYPE D: Phase Pairs (1 + e^a + e^b - e^g)
     # Padded values are masked to multiplicative identity.
     # ====================================================================
-    rowsum_a_d = jnp.sum(circuit.d_param_bits_a * param_vals, axis=-1) % 2
-    rowsum_b_d = jnp.sum(circuit.d_param_bits_b * param_vals, axis=-1) % 2
+    rowsum_a_d = _matmul_gf2(circuit.d_param_bits_a, param_vals)
+    rowsum_b_d = _matmul_gf2(circuit.d_param_bits_b, param_vals)
 
     alpha = (circuit.d_const_alpha + rowsum_a_d * 4) % 8
     beta = (circuit.d_const_beta + rowsum_b_d * 4) % 8
     gamma = (alpha + beta) % 8
 
-    # 1 + e^a + e^b - e^g, shape: (num_graphs, max_d, 4)
     term_vals_d_exact = (
         _IDENTITY + _UNIT_PHASES[alpha] + _UNIT_PHASES[beta] - _UNIT_PHASES[gamma]
     )
@@ -151,12 +136,11 @@ def evaluate(
     term_vals_d_exact = jnp.where(d_mask[..., None], term_vals_d_exact, _IDENTITY)
 
     term_vals_d = ExactScalarArray(term_vals_d_exact)
-    summands_d = term_vals_d.prod(axis=1)  # (num_graphs, 4)
+    summands_d = term_vals_d.prod(axis=-2)
 
     # ====================================================================
     # FINAL COMBINATION
     # ====================================================================
-
     static_phases = ExactScalarArray(_UNIT_PHASES[circuit.phase_indices])
     float_factor = ExactScalarArray(circuit.floatfactor)
 
@@ -165,13 +149,12 @@ def evaluate(
         [summands_a, summands_b, summands_c, summands_d, static_phases, float_factor],
     )
 
-    if not has_approximate_floatfactor:
-        # Add initial power2 from circuit compilation
+    if not circuit.has_approximate_floatfactors:
         total_summands = ExactScalarArray(
             total_summands.coeffs, total_summands.power + circuit.power2
         )
         total_summands = total_summands.reduce()
-        return total_summands.sum()
+        return total_summands.sum().to_complex()
     else:
         return jnp.sum(
             total_summands.to_complex()
@@ -179,22 +162,3 @@ def evaluate(
             * 2.0**circuit.power2,
             axis=-1,
         )
-
-
-_evaluate_batch = jax.vmap(evaluate, in_axes=(None, 0, None))
-
-
-def evaluate_batch(circuit: CompiledScalarGraphs, param_vals: Array) -> Array:
-    """Evaluate compiled circuit with batched parameter values.
-
-    Args:
-        circuit: Compiled circuit representation.
-        param_vals: Binary parameter values, shape (batch_size, n_params).
-
-    Returns:
-        Complex amplitudes for each parameter configuration, shape (batch_size,).
-
-    """
-    if circuit.has_approximate_floatfactors:
-        return _evaluate_batch(circuit, param_vals, True)
-    return _evaluate_batch(circuit, param_vals, False).to_complex()

--- a/src/tsim/core/exact_scalar.py
+++ b/src/tsim/core/exact_scalar.py
@@ -111,11 +111,11 @@ class ExactScalarArray(eqx.Module):
         # TODO: check for overflow and potentially refactor sum routine to scan
         # the array and reduce scalars every couple steps
 
-        min_power = jnp.min(self.power, keepdims=False, axis=-1)
+        min_power = jnp.min(self.power, keepdims=True, axis=-1)
         pow = (self.power - min_power)[..., None]
         aligned_coeffs = self.coeffs * 2**pow
         summed_coeffs = jnp.sum(aligned_coeffs, axis=-2)
-        return ExactScalarArray(summed_coeffs, min_power)
+        return ExactScalarArray(summed_coeffs, min_power.squeeze(-1))
 
     def prod(self, axis: int = -1) -> "ExactScalarArray":
         """Compute product along the specified axis using associative scan.


### PR DESCRIPTION
Adresses #31 

This pull request refactors the circuit evaluation logic in `src/tsim/compile/evaluate.py` to improve batched evaluation performance and simplify the implementation.

The batch dimension is now introduced explicitly in the `evaluate` function (as opposed to implicitly using jax's `vmap`).

Additionally, matrix multiplication is performed using BLAS kernels by converting from uint8 to fp32.