### PR TITLE
Implement sparse geometric channel sampler

### DIFF
--- a/src/tsim/sampler.py
+++ b/src/tsim/sampler.py
@@ -157,8 +157,7 @@ class _CompiledSamplerBase:
         prepared = prepare_graph(circuit, sample_detectors=sample_detectors)
         self._program = compile_program(prepared, mode=mode)
 
-        self._key, subkey = jax.random.split(self._key)
-        channel_seed = int(jax.random.randint(subkey, (), 0, 2**30))
+        channel_seed = int(np.random.default_rng(seed).integers(0, 2**30))
         self._channel_sampler = ChannelSampler(
             channel_probs=prepared.channel_probs,
             error_transform=prepared.error_transform,
@@ -175,7 +174,8 @@ class _CompiledSamplerBase:
 
         batches: list[jax.Array] = []
         for _ in range(ceil(shots / batch_size)):
-            f_params = self._channel_sampler.sample(batch_size)
+            f_params_np = self._channel_sampler.sample(batch_size)
+            f_params = jnp.asarray(f_params_np)
             self._key, subkey = jax.random.split(self._key)
             samples = sample_program(self._program, f_params, subkey)
             batches.append(samples)
@@ -406,7 +406,7 @@ class CompiledStateProbs(_CompiledSamplerBase):
             Array of probabilities P(state | error_sample) for each error sample.
 
         """
-        f_samples = self._channel_sampler.sample(batch_size)
+        f_samples = jnp.asarray(self._channel_sampler.sample(batch_size))
         p_norm = jnp.ones(batch_size)
         p_joint = jnp.ones(batch_size)
 

--- a/test/integration/test_sampler_circuits.py
+++ b/test/integration/test_sampler_circuits.py
@@ -21,7 +21,7 @@ def test_sample_bell_state():
     m = sampler.sample(100)
 
     assert np.array_equal(m[:, 0], m[:, 1])
-    assert np.count_nonzero(m[:, 0]) == 53
+    assert np.count_nonzero(m[:, 0]) == 48
 
 
 def test_detector_sampler_bell_state_with_measurement_error():
@@ -52,7 +52,7 @@ def test_t_gate():
     )
     sampler = c.compile_sampler(seed=0)
     m = sampler.sample(100)
-    assert np.count_nonzero(m) == 16
+    assert np.count_nonzero(m) == 9
 
 
 def test_s_gate():
@@ -66,7 +66,7 @@ def test_s_gate():
     )
     sampler = c.compile_sampler(seed=0)
     m = sampler.sample(100)
-    assert np.count_nonzero(m) == 53
+    assert np.count_nonzero(m) == 48
 
 
 def test_t_dag_gate():
@@ -114,13 +114,13 @@ def test_r_gate():
     )
     sampler = c.compile_sampler(seed=0)
     m = sampler.sample(10)
-    assert np.count_nonzero(m[:, 0]) == 4
-    assert np.count_nonzero(m[:, 1]) == 6
+    assert np.count_nonzero(m[:, 0]) == 7
+    assert np.count_nonzero(m[:, 1]) == 4
     assert np.count_nonzero(m[:, 2]) == 0
 
     det_sampler = c.compile_detector_sampler(seed=0)
     d = det_sampler.sample(10)
-    assert np.count_nonzero(d) == 4
+    assert np.count_nonzero(d) == 7
 
 
 @pytest.mark.parametrize(

--- a/test/unit/noise/test_channels.py
+++ b/test/unit/noise/test_channels.py
@@ -1,12 +1,9 @@
-import jax
-import jax.numpy as jnp
 import numpy as np
 from numpy.testing import assert_allclose
 
 from tsim.noise.channels import (
     Channel,
     ChannelSampler,
-    _sample_channels,
     absorb_subset_channels,
     correlated_error_probs,
     error_probs,
@@ -140,8 +137,20 @@ class TestCorrelatedErrorProbs:
         assert_allclose(probs[4], 0.0)  # Third error (blocked)
 
 
+def _sample_channels(channels, matrix, n_samples, seed=42):
+    """Sample from channels using the ChannelSampler infrastructure."""
+    sampler = object.__new__(ChannelSampler)
+    sampler.channels = channels
+    sampler.signature_matrix = np.asarray(matrix, dtype=np.uint8)
+    sampler._rng = np.random.default_rng(seed)
+    sampler._sparse_data = ChannelSampler._precompute_sparse(
+        channels, sampler.signature_matrix
+    )
+    return sampler.sample(n_samples)
+
+
 def assert_sampling_matches(
-    matrix: jnp.ndarray,
+    matrix: np.ndarray,
     channels_before: list[Channel],
     channels_after: list[Channel],
     n_samples: int = 500_000,
@@ -152,13 +161,11 @@ def assert_sampling_matches(
 
     Compares the mean of each output bit (f-variable) between the two channel sets.
     """
-    key1 = jax.random.key(seed)
-    bits1 = _sample_channels(key1, channels_before, matrix, n_samples)
-    freq1 = np.mean(np.asarray(bits1), axis=0)
+    bits1 = _sample_channels(channels_before, matrix, n_samples, seed=seed)
+    freq1 = np.mean(bits1, axis=0)
 
-    key2 = jax.random.key(seed + 1)
-    bits2 = _sample_channels(key2, channels_after, matrix, n_samples)
-    freq2 = np.mean(np.asarray(bits2), axis=0)
+    bits2 = _sample_channels(channels_after, matrix, n_samples, seed=seed + 1)
+    freq2 = np.mean(bits2, axis=0)
 
     assert_allclose(
         freq1,
@@ -251,13 +258,13 @@ class TestMergeIdenticalChannels:
 
     def test_sampling_matches_after_merge(self):
         """Sampling statistics should match before and after merging."""
-        mat = jnp.array(
+        mat = np.array(
             [
                 [1, 0, 0],
                 [0, 1, 0],
                 [1, 1, 0],
             ],
-            dtype=jnp.uint8,
+            dtype=np.uint8,
         )
 
         c1 = Channel(probs=error_probs(0.1), unique_col_ids=(0,))
@@ -357,7 +364,7 @@ class TestNormalizeChannels:
 
         normalized = normalize_channels([c])
 
-        mat = jnp.eye(2, dtype=jnp.uint8)
+        mat = np.eye(2, dtype=np.uint8)
         assert_sampling_matches(mat, [c], normalized)
 
 
@@ -406,13 +413,13 @@ class TestAbsorbSubsetChannels:
 
     def test_sampling_matches_after_absorb(self):
         """Sampling statistics should match before and after absorption."""
-        mat = jnp.array(
+        mat = np.array(
             [
                 [1, 0, 0],
                 [0, 1, 0],
                 [1, 1, 0],
             ],
-            dtype=jnp.uint8,
+            dtype=np.uint8,
         )
 
         # c1 has signature (0,), c2 has signatures (0, 1)
@@ -435,14 +442,14 @@ class TestSimplifyChannels:
 
     def test_simplify_mixed_channels(self):
         """Test simplification with a mix of channel types."""
-        mat = jnp.array(
+        mat = np.array(
             [
                 [1, 0, 0, 0],
                 [0, 1, 0, 0],
                 [0, 0, 1, 0],
                 [1, 1, 1, 0],
             ],
-            dtype=jnp.uint8,
+            dtype=np.uint8,
         )
 
         # Create channels:
@@ -467,7 +474,7 @@ class TestSimplifyChannels:
 
     def test_simplify_many_1bit_channels(self):
         """Test simplification of many 1-bit channels with same signature."""
-        mat = jnp.array([[1], [1]], dtype=jnp.uint8)
+        mat = np.array([[1], [1]], dtype=np.uint8)
 
         # 10 channels all with the same signature
         channels = [
@@ -481,13 +488,13 @@ class TestSimplifyChannels:
 
     def test_simplify_preserves_independent_channels(self):
         """Channels with disjoint signatures should remain separate."""
-        mat = jnp.array(
+        mat = np.array(
             [
                 [1, 0, 0],
                 [0, 1, 0],
                 [0, 0, 1],
             ],
-            dtype=jnp.uint8,
+            dtype=np.uint8,
         )
 
         c1 = Channel(probs=error_probs(0.1), unique_col_ids=(0,))
@@ -502,31 +509,27 @@ class TestSimplifyChannels:
 
 
 class TestSampleChannels:
-    """Tests for _sample_channels function."""
+    """Tests for channel sampling."""
 
     def test_single_channel(self):
         """Test that sampling produces correct frequencies for a single channel."""
-        mat = jnp.array([[1]], dtype=jnp.uint8)
+        mat = np.array([[1]], dtype=np.uint8)
         c = Channel(probs=error_probs(0.3), unique_col_ids=(0,))
 
-        key = jax.random.key(42)
-        bits = _sample_channels(key, [c], mat, 100_000)
-        freq = np.mean(np.asarray(bits[:, 0]))
+        bits = _sample_channels([c], mat, 100_000)
+        freq = np.mean(bits[:, 0])
 
         assert_allclose(freq, 0.3, rtol=0.05)
 
     def test_xor_two_channels(self):
         """Test that sampling correctly XORs two independent channels."""
-        # Matrix shape: (num_signatures, num_f_vars)
-        # Both signatures (0 and 1) affect f0
-        mat = jnp.array([[1], [1]], dtype=jnp.uint8)
+        mat = np.array([[1], [1]], dtype=np.uint8)
 
         c1 = Channel(probs=error_probs(0.2), unique_col_ids=(0,))
         c2 = Channel(probs=error_probs(0.3), unique_col_ids=(1,))
 
-        key = jax.random.key(42)
-        bits = _sample_channels(key, [c1, c2], mat, 100_000)
-        freq = np.mean(np.asarray(bits[:, 0]))
+        bits = _sample_channels([c1, c2], mat, 100_000)
+        freq = np.mean(bits[:, 0])
 
         # P(f0=1) = P(e0 XOR e1 = 1) = 0.2*0.7 + 0.3*0.8 = 0.14 + 0.24 = 0.38
         expected = 0.2 * 0.7 + 0.3 * 0.8

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -38,10 +38,10 @@ def test_seed():
     )
     for _ in range(2):
         sampler = c.compile_sampler(seed=0)
+        assert np.count_nonzero(sampler.sample(100)) == 48
         assert np.count_nonzero(sampler.sample(100)) == 53
         assert np.count_nonzero(sampler.sample(100)) == 52
         assert np.count_nonzero(sampler.sample(100)) == 50
-        assert np.count_nonzero(sampler.sample(100)) == 48
 
 
 def test_sampler_repr():


### PR DESCRIPTION
This was suggested and implemented in https://github.com/kh428/accel-cutting-magic-state

This PR removes the dense JAX-based sampler and replaces it with a sparse NumPy implementation based on sampling from the geometric distribution. Rather than sampling channel bits independently from a Bernoulli distribution, we instead sample the positions of the next 1-bits directly. For low physical error rates, this approach is significantly more efficient. Stim uses the same strategy to generate random bits.

As a consequence, sampling is no longer GPU-accelerated. However, in practice, most workloads are not bottlenecked by the sampling step, and for low error rates the sparse CPU implementation outperforms the dense GPU approach anyways.

An additional benefit of the NumPy-based implementation is that it simplifies the incorporation of postselection masks (#41)