### PR TITLE
White background for svg plots

### DIFF
--- a/src/tsim/utils/diagram.py
+++ b/src/tsim/utils/diagram.py
@@ -72,7 +72,7 @@ def wrap_svg(
         return svg
 
     return f"""
-    <div style="overflow-x: scroll; ">
+    <div style="overflow-x: scroll; background: white; width: fit-content;">
     <div style="width: {computed_width}px">
     {svg}
     </div>


### PR DESCRIPTION
Useful for dark mode. Suggested by @jasonhan3 

Before
<img width="553" height="144" alt="image" src="https://github.com/user-attachments/assets/c90dc452-b630-4131-8186-3f4731049897" />

After
<img width="564" height="168" alt="image" src="https://github.com/user-attachments/assets/349611bd-3c5f-429e-9e84-1285b98205ce" />
