### PR TITLE
Add MPAD instruction

### DIFF
--- a/src/tsim/core/instructions.py
+++ b/src/tsim/core/instructions.py
@@ -769,6 +769,22 @@ def mpp(
     m(b, aux, invert=invert)
 
 
+def mpad(b: GraphRepresentation, value: int, p: float = 0) -> None:
+    """Pad measurement record with a fixed bit value.
+
+    Args:
+        b: The graph representation to modify.
+        value: The bit value to record (0 or 1).
+        p: Error probability for the recorded bit.
+
+    """
+    aux = -2
+    r(b, aux)
+    if value == 1:
+        x(b, aux)
+    m(b, aux, p=p)
+
+
 def mr(b: GraphRepresentation, qubit: int, p: float = 0, invert: bool = False) -> None:
     """Z-basis demolition measurement (optionally noisy).
 

--- a/src/tsim/core/parse.py
+++ b/src/tsim/core/parse.py
@@ -12,6 +12,7 @@ from tsim.core.instructions import (
     correlated_error,
     detector,
     finalize_correlated_error,
+    mpad,
     mpp,
     observable_include,
     r_x,
@@ -145,6 +146,12 @@ def parse_stim_circuit(
                     current_paulis = []
                     invert = False
 
+            continue
+        if name == "MPAD":
+            args = instruction.gate_args_copy()
+            p = args[0] if args else 0
+            for target in instruction.targets_copy():
+                mpad(b, target.value, p=p)
             continue
         if name == "E" or name == "ELSE_CORRELATED_ERROR":
             if name == "E":

--- a/test/integration/test_sampler_circuits.py
+++ b/test/integration/test_sampler_circuits.py
@@ -576,3 +576,59 @@ def test_many_rx_gates(n: int):
     sampler = CompiledStateProbs(c)
     mat = get_matrix(sampler)
     assert np.allclose(mat, np.eye(2), atol=1e-6)
+
+
+def test_mpad_zero():
+    c = Circuit("""
+        MPAD 0
+    """)
+    sampler = c.compile_sampler()
+    samples = sampler.sample(10)
+    assert (samples == 0).all()
+
+
+def test_mpad_one():
+    c = Circuit("""
+        MPAD 1
+    """)
+    sampler = c.compile_sampler()
+    samples = sampler.sample(10)
+    assert (samples == 1).all()
+
+
+def test_mpad_multiple():
+    c = Circuit("""
+        MPAD 0 1 1 0
+    """)
+    sampler = c.compile_sampler()
+    samples = sampler.sample(10)
+    assert (samples[:, 0] == 0).all()
+    assert (samples[:, 1] == 1).all()
+    assert (samples[:, 2] == 1).all()
+    assert (samples[:, 3] == 0).all()
+
+
+def test_mpad_with_measurements():
+    c = Circuit("""
+        R 0
+        X 0
+        M 0
+        MPAD 0
+        M 0
+    """)
+    sampler = c.compile_sampler()
+    samples = sampler.sample(10)
+    # M 0 after X -> 1, MPAD 0 -> 0, M 0 after implicit reset -> 1
+    assert (samples[:, 0] == 1).all()
+    assert (samples[:, 1] == 0).all()
+    assert (samples[:, 2] == 1).all()
+
+
+def test_mpad_detector():
+    c = Circuit("""
+        MPAD 1
+        DETECTOR rec[-1]
+    """)
+    sampler = c.compile_detector_sampler()
+    samples = sampler.sample(10)
+    assert (samples == 1).all()

--- a/test/unit/core/test_parse.py
+++ b/test/unit/core/test_parse.py
@@ -182,3 +182,41 @@ class TestCorrelatedErrorState:
         # X_ERROR: 1 bit, CORRELATED_ERROR: 1 bit, Z_ERROR: 1 bit
         assert b.num_error_bits == 3
         assert len(b.channel_probs) == 3
+
+
+class TestParseMPAD:
+    """Tests for parsing MPAD (measurement record padding) instructions."""
+
+    def test_mpad_single_zero(self):
+        """MPAD 0 should add one measurement record entry."""
+        circuit = stim.Circuit("MPAD 0")
+        b = parse_stim_circuit(circuit)
+        assert len(b.rec) == 1
+
+    def test_mpad_single_one(self):
+        """MPAD 1 should add one measurement record entry."""
+        circuit = stim.Circuit("MPAD 1")
+        b = parse_stim_circuit(circuit)
+        assert len(b.rec) == 1
+
+    def test_mpad_multiple_targets(self):
+        """MPAD with multiple targets should add one record per target."""
+        circuit = stim.Circuit("MPAD 0 1 0 1")
+        b = parse_stim_circuit(circuit)
+        assert len(b.rec) == 4
+
+    def test_mpad_mixed_with_measurements(self):
+        """MPAD records should interleave correctly with regular measurements."""
+        circuit = stim.Circuit("""
+            M 0
+            MPAD 1
+            M 1
+        """)
+        b = parse_stim_circuit(circuit)
+        assert len(b.rec) == 3
+
+    def test_mpad_in_repeat_block(self):
+        """MPAD inside a repeat block should be expanded correctly."""
+        circuit = stim.Circuit("REPEAT 3 {\n    MPAD 0 1\n}")
+        b = parse_stim_circuit(circuit)
+        assert len(b.rec) == 6


### PR DESCRIPTION
## Summary
- Implement `MPAD` gate that pads the measurement record with fixed bit values (0 or 1), with optional noise probability
- Uses the auxiliary qubit pattern (qubit `-2`): reset, conditionally X-flip, then measure

Closes #75

## Test plan
- [x] Unit tests for parsing: single/multiple targets, mixed with measurements, repeat blocks
- [x] Integration tests for sampling: deterministic 0/1 values, interleaved with M, detector sampler

🤖 Generated with [Claude Code](https://claude.com/claude-code)