### PR TITLE
Add handling for empty programs in sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `H_NXY`, `H_NXZ`, `H_NYZ` Hadamard-like gate variants with negated axes
 - `II` two-qubit identity instruction that acts trivially
 
+### Fixed
+- Samplers now gracefully handle circuits with no measurements or no detectors, returning empty `(shots, 0)` arrays matching stim's behavior instead of raising an error
+
 ### Changed
 - `MXX`, `MYY`, `MZZ` instructions are now dispatched through the gate table instead of being special-cased in the parser
+- `I_ERROR`, `II_ERROR`, and `QUBIT_COORDS` instructions now allocate qubit lanes instead of being silently skipped
 
 ## [0.1.2] - 2026-04-07
 

--- a/src/tsim/sampler.py
+++ b/src/tsim/sampler.py
@@ -130,6 +130,10 @@ def sample_program(
         match the original output indices.
 
     """
+    if len(program.components) == 0:
+        batch_size = f_params.shape[0]
+        return jnp.empty((batch_size, 0), dtype=jnp.bool_)
+
     results: list[jax.Array] = []
 
     for component in program.components:
@@ -339,7 +343,7 @@ class _CompiledSamplerBase:
         return (
             f"{type(self).__name__}({np.sum(c_graphs)} graphs, "
             f"{error_channel_bits} error channel bits, "
-            f"{np.max(num_outputs)} outputs for largest cc, "
+            f"{np.max(num_outputs) if num_outputs else 0} outputs for largest cc, "
             f"≤ {np.max(c_params) if c_params else 0} parameters, {np.sum(c_a_terms)} A terms, "
             f"{np.sum(c_b_terms)} B terms, "
             f"{np.sum(c_c_terms)} C terms, {np.sum(c_d_terms)} D terms, "

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -30,6 +30,55 @@ def test_detector_sampler_args():
     assert np.array_equal(o, np.array([[1]]))
 
 
+def test_measurement_sampler_no_measurements():
+    """Measurement sampler on a circuit with no measurements returns (shots, 0)."""
+    c = Circuit("H 0")
+    sampler = c.compile_sampler()
+    result = sampler.sample(5)
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == np.bool_
+    assert result.shape == (5, 0)
+
+
+def test_detector_sampler_no_detectors():
+    """Detector sampler on a circuit with no detectors returns (shots, 0)."""
+    c = Circuit("H 0\nM 0")
+    sampler = c.compile_detector_sampler()
+    result = sampler.sample(5)
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == np.bool_
+    assert result.shape == (5, 0)
+
+
+def test_detector_sampler_no_detectors_separate_observables():
+    """Detector sampler with separate_observables and no detectors returns two (shots, 0) arrays."""
+    c = Circuit("H 0\nM 0")
+    sampler = c.compile_detector_sampler()
+    dets, obs = sampler.sample(5, separate_observables=True)
+    assert dets.dtype == np.bool_
+    assert dets.shape == (5, 0)
+    assert obs.dtype == np.bool_
+    assert obs.shape == (5, 0)
+
+
+def test_detector_sampler_no_detectors_bit_packed():
+    """Detector sampler with bit_packed and no detectors returns (shots, 0) uint8."""
+    c = Circuit("H 0\nM 0")
+    sampler = c.compile_detector_sampler()
+    result = sampler.sample(5, bit_packed=True)
+    assert result.dtype == np.uint8
+    assert result.shape == (5, 0)
+
+
+def test_sampler_repr_no_measurements():
+    """repr() on a sampler with no measurements should not error."""
+    c = Circuit("H 0")
+    sampler = c.compile_sampler()
+    repr_str = repr(sampler)
+    assert "CompiledMeasurementSampler" in repr_str
+    assert "0 outputs" in repr_str
+
+
 def test_seed():
     c = Circuit("""
         H 0


### PR DESCRIPTION
This pull request improves the robustness of the sampler by ensuring it gracefully handles circuits with no measurements or detectors, aligning its behavior with stim. Previously, circuits without measurements or detectors raised ValueErrors when trying to sample from them.