### PR TITLE
Zoomable svg diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Zoomable timeline and timeslice diagrams. `Circuit.diagram` now accepts a `zoomable` option, enabled by default, to support pan and zoom in notebooks for the `timeline-svg` and `timeslice-svg` diagram types.
 - `CXSWAP`, `CZSWAP`, `SWAPCX`, `SWAPCZ` two-qubit gate instructions
 - `C_NXYZ`, `C_XNYZ`, `C_XYNZ`, `C_NZYX`, `C_ZNYX`, `C_ZYNX` axis-cycling gate variants with negated axes
 - `H_NXY`, `H_NXZ`, `H_NYZ` Hadamard-like gate variants with negated axes

--- a/src/tsim/circuit.py
+++ b/src/tsim/circuit.py
@@ -587,8 +587,9 @@ class Circuit:
         tick: int | range | None = None,
         filter_coords: Iterable[Iterable[float] | stim.DemTarget] = ((),),
         rows: int | None = None,
-        height: float | Literal["auto"] | None = "auto",
+        height: float | None = None,
         width: float | None = None,
+        zoomable: bool = True,
         **kwargs: Any,
     ) -> Any:
         """Return a diagram of the circuit, from a variety of options.
@@ -631,11 +632,16 @@ class Circuit:
                 be included), a stim.DemTarget (specifying a detector or observable
                 to include), a string like "D5" or "L0" specifying a detector or
                 observable to include.
-            height: Optional height for the rendered diagram. If "auto", the height will
-                be automatically determined based on the number of qubits. Only one of
-                height or width should be specified.
-            width: Optional width for the rendered diagram. Only one of height or width
-                should be specified.
+            height: Optional height for the rendered diagram in pixels. Only applied
+                to timeline-svg and timeslice-svg diagram types. When both
+                height and width are None, the height is automatically determined
+                based on the number of qubits. When only one dimension is given,
+                the other is computed from the SVG aspect ratio.
+            width: Optional width for the rendered diagram in pixels. Only applied
+                to timeline-svg and timeslice-svg diagram types.
+            zoomable: If True (default), wraps SVG diagrams in an interactive
+                container with pan and Ctrl/Cmd+wheel zoom. Only applies to
+                timeline-svg and timeslice-svg diagram types.
             **kwargs: Additional keyword arguments passed to the underlying diagram renderer.
 
         Returns:
@@ -650,13 +656,8 @@ class Circuit:
             "timeline-svg",
             "timeslice-svg",
         ]:
-            zoomable = False
-            if height == "auto":
-                if width is not None or type == "timeslice-svg":
-                    height = None
-                else:
-                    zoomable = True
-                    height = min(30 * self.num_qubits + 50, 700)
+            if height is None and width is None and type == "timeline-svg":
+                height = min(30 * self.num_qubits + 50, 700)
             return render_svg(
                 self._stim_circ,
                 type,

--- a/src/tsim/circuit.py
+++ b/src/tsim/circuit.py
@@ -650,10 +650,12 @@ class Circuit:
             "timeline-svg",
             "timeslice-svg",
         ]:
+            zoomable = False
             if height == "auto":
                 if width is not None or type == "timeslice-svg":
                     height = None
                 else:
+                    zoomable = True
                     height = min(30 * self.num_qubits + 50, 700)
             return render_svg(
                 self._stim_circ,
@@ -663,6 +665,7 @@ class Circuit:
                 rows=rows,
                 width=width,
                 height=height,
+                zoomable=zoomable,
             )
         elif type == "pyzx":
             return render_pyzx_d3(self._stim_circ, kwargs)

--- a/src/tsim/circuit.py
+++ b/src/tsim/circuit.py
@@ -587,7 +587,7 @@ class Circuit:
         tick: int | range | None = None,
         filter_coords: Iterable[Iterable[float] | stim.DemTarget] = ((),),
         rows: int | None = None,
-        height: float | None = None,
+        height: float | Literal["auto"] | None = "auto",
         width: float | None = None,
         **kwargs: Any,
     ) -> Any:
@@ -631,8 +631,11 @@ class Circuit:
                 be included), a stim.DemTarget (specifying a detector or observable
                 to include), a string like "D5" or "L0" specifying a detector or
                 observable to include.
-            height: Optional height for the rendered diagram.
-            width: Optional width for the rendered diagram.
+            height: Optional height for the rendered diagram. If "auto", the height will
+                be automatically determined based on the number of qubits. Only one of
+                height or width should be specified.
+            width: Optional width for the rendered diagram. Only one of height or width
+                should be specified.
             **kwargs: Additional keyword arguments passed to the underlying diagram renderer.
 
         Returns:
@@ -647,6 +650,11 @@ class Circuit:
             "timeline-svg",
             "timeslice-svg",
         ]:
+            if height == "auto":
+                if width is not None or type == "timeslice-svg":
+                    height = None
+                else:
+                    height = min(30 * self.num_qubits + 50, 700)
             return render_svg(
                 self._stim_circ,
                 type,

--- a/src/tsim/circuit.py
+++ b/src/tsim/circuit.py
@@ -634,10 +634,11 @@ class Circuit:
                 to include), a string like "D5" or "L0" specifying a detector or
                 observable to include.
             height: Optional height for the rendered diagram in pixels. Only applied
-                to timeline-svg and timeslice-svg diagram types. When both
-                height and width are None, the height is automatically determined
-                based on the number of qubits. When only one dimension is given,
-                the other is computed from the SVG aspect ratio.
+                to timeline-svg and timeslice-svg diagram types. For
+                timeline-svg, when both height and width are None, the height is
+                automatically determined based on the number of qubits. When only
+                one dimension is given, the other is computed from the SVG aspect
+                ratio.
             width: Optional width for the rendered diagram in pixels. Only applied
                 to timeline-svg and timeslice-svg diagram types.
             zoomable: If True (default), wraps SVG diagrams in an interactive

--- a/src/tsim/utils/diagram.py
+++ b/src/tsim/utils/diagram.py
@@ -1,6 +1,7 @@
 """SVG diagram rendering for quantum circuits."""
 
 import re
+import uuid
 from dataclasses import dataclass
 from fractions import Fraction
 from typing import Any, Iterable
@@ -39,13 +40,21 @@ class GateLabel:
     annotation: str | None = None  # Optional annotation (shown as text below the gate)
 
 
-def _width_from_viewbox(svg: str, height: float) -> float | None:
-    """Compute width from an SVG viewBox while preserving aspect ratio."""
+def _viewbox_size(svg: str) -> tuple[float, float] | None:
+    """Return (width, height) parsed from an SVG viewBox attribute."""
     m = re.search(r'viewBox="[^"]*\s([\d.]+)\s+([\d.]+)"', svg)
     if m is None:
         return None
-
     w, h = map(float, m.groups())
+    return w, h
+
+
+def _width_from_viewbox(svg: str, height: float) -> float | None:
+    """Compute width from an SVG viewBox while preserving aspect ratio."""
+    size = _viewbox_size(svg)
+    if size is None:
+        return None
+    w, h = size
     if h == 0:
         return None
     return float(height) / h * w
@@ -87,6 +96,84 @@ def wrap_svg(
     </div>
     </div>
     """
+
+
+def wrap_svg_zoomable(svg: str, *, height: float = 700) -> str:
+    """Wrap an SVG in a zoomable, scrollable container.
+
+    The container fills the available width and has the given pixel height.
+    Users can pan by scrolling and zoom with pinch-zoom (trackpad) or
+    Ctrl/Cmd + wheel. Zoom is anchored at the cursor position.
+
+    Args:
+        svg: Raw SVG markup.
+        height: Pixel height of the container.
+
+    """
+    size = _viewbox_size(svg)
+    if size is None or size[1] == 0:
+        nat_w, nat_h = 800.0, 200.0
+    else:
+        nat_w, nat_h = size
+
+    # Stim SVGs only have a viewBox, no explicit width/height. Inside an
+    # inline-block container they collapse, so force the SVG to render at its
+    # natural pixel size.
+    sized_svg = re.sub(
+        r"<svg\b",
+        f'<svg width="{nat_w}" height="{nat_h}"',
+        svg,
+        count=1,
+    )
+
+    # Initial scale fits the SVG's full height into the panel.
+    initial_scale = height / nat_h if nat_h > 0 else 1.0
+    init_w = nat_w * initial_scale
+    init_h = nat_h * initial_scale
+
+    uid = uuid.uuid4().hex[:12]
+    return f"""
+<div data-tsim-zoom="{uid}" style="width:100%; height:{height}px; overflow:auto; background:white; border:1px solid #eee; position:relative;">
+  <div style="display:inline-block; width:{init_w}px; height:{init_h}px;">
+    <div style="transform-origin:0 0; display:block; width:{nat_w}px; height:{nat_h}px; transform:scale({initial_scale});">
+      {sized_svg}
+    </div>
+  </div>
+</div>
+<script>
+(function() {{
+  var wrap = document.querySelector('[data-tsim-zoom="{uid}"]');
+  if (!wrap || wrap.dataset.tsimZoomInit) return;
+  wrap.dataset.tsimZoomInit = "1";
+  var size = wrap.firstElementChild;
+  var xform = size.firstElementChild;
+  var natW = {nat_w};
+  var natH = {nat_h};
+  var scale = {initial_scale};
+  function apply() {{
+    xform.style.transform = 'scale(' + scale + ')';
+    size.style.width = (natW * scale) + 'px';
+    size.style.height = (natH * scale) + 'px';
+  }}
+  apply();
+  wrap.addEventListener('wheel', function(e) {{
+    if (e.ctrlKey || e.metaKey) {{
+      e.preventDefault();
+      var rect = wrap.getBoundingClientRect();
+      var mx = e.clientX - rect.left + wrap.scrollLeft;
+      var my = e.clientY - rect.top + wrap.scrollTop;
+      var factor = Math.exp(-e.deltaY * 0.01);
+      var newScale = Math.min(Math.max(0.02, scale * factor), 40);
+      var ratio = newScale / scale;
+      scale = newScale;
+      apply();
+      wrap.scrollLeft = mx * ratio - (e.clientX - rect.left);
+      wrap.scrollTop = my * ratio - (e.clientY - rect.top);
+    }}
+  }}, {{ passive: false }});
+}})();
+</script>
+"""
 
 
 def _subscript(text: str) -> str:
@@ -286,6 +373,7 @@ def render_svg(
     rows: int | None = None,
     width: float | None = None,
     height: float | None = None,
+    zoomable: bool = False,
 ) -> Diagram:
     """Render a stim circuit timeline/timeslice diagram with custom labels."""
     modified_circ, placeholder_id_to_labels = tagged_gates_to_placeholder(c)
@@ -293,7 +381,10 @@ def render_svg(
         modified_circ.diagram(type, tick=tick, filter_coords=filter_coords, rows=rows)
     )
     svg = placeholders_to_t(svg_with_placeholders, placeholder_id_to_labels)
-    wrapped = wrap_svg(svg, width=width, height=height)
+    if zoomable:
+        wrapped = wrap_svg_zoomable(svg, height=height if height is not None else 700)
+    else:
+        wrapped = wrap_svg(svg, width=width, height=height)
     return Diagram(wrapped)
 
 

--- a/src/tsim/utils/diagram.py
+++ b/src/tsim/utils/diagram.py
@@ -19,9 +19,16 @@ from tsim.core.parse import parse_stim_circuit
 class Diagram:
     """Wrapper for SVG diagram with Jupyter notebook display support."""
 
-    def __init__(self, svg: str):
-        """Create a diagram from SVG markup."""
+    def __init__(self, svg: str, html: str):
+        """Create a diagram from raw SVG markup and an HTML-wrapped version.
+
+        Args:
+            svg: Raw SVG markup suitable for saving to ``.svg`` files.
+            html: HTML-wrapped version for interactive Jupyter display.
+
+        """
         self._svg = svg
+        self._html = html
 
     def __str__(self) -> str:
         """Return the raw SVG string."""
@@ -29,7 +36,7 @@ class Diagram:
 
     def _repr_html_(self) -> Any:
         """Return HTML representation for Jupyter notebook display."""
-        return self._svg
+        return self._html
 
 
 @dataclass
@@ -397,12 +404,12 @@ def render_svg(
             height = width / size[0] * size[1]
 
     if zoomable:
-        wrapped = wrap_svg_zoomable(
+        html = wrap_svg_zoomable(
             svg, width=width, height=height if height is not None else 700
         )
     else:
-        wrapped = wrap_svg(svg, width=width, height=height)
-    return Diagram(wrapped)
+        html = wrap_svg(svg, width=width, height=height)
+    return Diagram(svg, html)
 
 
 def render_pyzx_d3(stim_circ: stim.Circuit, kwargs: dict[str, Any]) -> GraphS:

--- a/src/tsim/utils/diagram.py
+++ b/src/tsim/utils/diagram.py
@@ -74,7 +74,11 @@ def wrap_svg(
         computed_width = _width_from_viewbox(svg, float(height))
 
     if computed_width is None:
-        return svg
+        return f"""
+        <div style="background: white">
+        {svg}
+        </div>
+        """
 
     return f"""
     <div style="overflow-x: scroll; background: white; width: fit-content;">

--- a/src/tsim/utils/diagram.py
+++ b/src/tsim/utils/diagram.py
@@ -66,23 +66,16 @@ def wrap_svg(
     width: float | None = None,
     height: float | None = None,
 ) -> str:
-    """Optionally wrap an SVG string in a scrolling container.
+    """Wrap an SVG string in a container div.
 
     Args:
         svg: Raw SVG markup.
-        width: Explicit width for the container.
-        height: Desired height; used to infer width from viewBox if width is not given.
+        width: Width of the container in pixels.
+        height: Height of the container in pixels (unused, kept for API
+            symmetry with :func:`wrap_svg_zoomable`).
 
     """
-    computed_width = width
-    if (
-        computed_width is None
-        and height is not None
-        and isinstance(height, (float, int))
-    ):
-        computed_width = _width_from_viewbox(svg, float(height))
-
-    if computed_width is None:
+    if width is None:
         return f"""
         <div style="background: white">
         {svg}
@@ -91,22 +84,26 @@ def wrap_svg(
 
     return f"""
     <div style="overflow-x: scroll; background: white; width: fit-content;">
-    <div style="width: {computed_width}px">
+    <div style="width: {width}px">
     {svg}
     </div>
     </div>
     """
 
 
-def wrap_svg_zoomable(svg: str, *, height: float = 700) -> str:
+def wrap_svg_zoomable(
+    svg: str, *, width: float | None = None, height: float = 700
+) -> str:
     """Wrap an SVG in a zoomable, scrollable container.
 
-    The container fills the available width and has the given pixel height.
-    Users can pan by scrolling and zoom with pinch-zoom (trackpad) or
-    Ctrl/Cmd + wheel. Zoom is anchored at the cursor position.
+    The container has the given pixel dimensions.  When *width* is ``None``
+    the container fills the available width.  Users can pan by scrolling
+    and zoom with pinch-zoom (trackpad) or Ctrl/Cmd + wheel.  Zoom is
+    anchored at the cursor position.
 
     Args:
         svg: Raw SVG markup.
+        width: Pixel width of the container, or ``None`` for full width.
         height: Pixel height of the container.
 
     """
@@ -126,15 +123,20 @@ def wrap_svg_zoomable(svg: str, *, height: float = 700) -> str:
         count=1,
     )
 
-    # Initial scale fits the SVG's full height into the panel.
-    initial_scale = height / nat_h if nat_h > 0 else 1.0
+    # Initial scale fits the SVG into the container.
+    scale_h = height / nat_h if nat_h > 0 else 1.0
+    if width is not None and nat_w > 0:
+        initial_scale = min(scale_h, width / nat_w)
+    else:
+        initial_scale = scale_h
     init_w = nat_w * initial_scale
     init_h = nat_h * initial_scale
 
+    width_style = f"width:{width}px" if width is not None else "width:100%"
     uid = uuid.uuid4().hex[:12]
     return f"""
-<div data-tsim-zoom="{uid}" style="width:100%; height:{height}px; overflow:auto; background:white; border:1px solid #eee; position:relative;">
-  <div style="display:inline-block; width:{init_w}px; height:{init_h}px;">
+<div data-tsim-zoom="{uid}" style="{width_style}; height:{height}px; overflow:auto; background:white; border:1px solid #eee; position:relative;">
+  <div style="display:inline-block; overflow:hidden; width:{init_w}px; height:{init_h}px;">
     <div style="transform-origin:0 0; display:block; width:{nat_w}px; height:{nat_h}px; transform:scale({initial_scale});">
       {sized_svg}
     </div>
@@ -150,6 +152,10 @@ def wrap_svg_zoomable(svg: str, *, height: float = 700) -> str:
   var natW = {nat_w};
   var natH = {nat_h};
   var scale = {initial_scale};
+  var cw = wrap.clientWidth;
+  if (cw > 0 && natW > 0) {{
+    scale = cw / natW;
+  }}
   function apply() {{
     xform.style.transform = 'scale(' + scale + ')';
     size.style.width = (natW * scale) + 'px';
@@ -373,7 +379,7 @@ def render_svg(
     rows: int | None = None,
     width: float | None = None,
     height: float | None = None,
-    zoomable: bool = False,
+    zoomable: bool = True,
 ) -> Diagram:
     """Render a stim circuit timeline/timeslice diagram with custom labels."""
     modified_circ, placeholder_id_to_labels = tagged_gates_to_placeholder(c)
@@ -381,8 +387,19 @@ def render_svg(
         modified_circ.diagram(type, tick=tick, filter_coords=filter_coords, rows=rows)
     )
     svg = placeholders_to_t(svg_with_placeholders, placeholder_id_to_labels)
+
+    # Compute the missing dimension from the SVG viewBox aspect ratio.
+    if width is None and height is not None:
+        width = _width_from_viewbox(svg, height)
+    elif height is None and width is not None:
+        size = _viewbox_size(svg)
+        if size is not None and size[0] != 0:
+            height = width / size[0] * size[1]
+
     if zoomable:
-        wrapped = wrap_svg_zoomable(svg, height=height if height is not None else 700)
+        wrapped = wrap_svg_zoomable(
+            svg, width=width, height=height if height is not None else 700
+        )
     else:
         wrapped = wrap_svg(svg, width=width, height=height)
     return Diagram(wrapped)

--- a/test/unit/utils/test_diagram.py
+++ b/test/unit/utils/test_diagram.py
@@ -19,9 +19,9 @@ def test_width_from_viewbox_scales_width():
     assert _width_from_viewbox(svg, 20.0) == pytest.approx(40.0)
 
 
-def test_wrap_svg_infers_width_from_height():
+def test_wrap_svg_uses_given_width():
     svg = '<svg viewBox="0 0 4 2"></svg>'
-    wrapped = wrap_svg(svg, height=10.0)
+    wrapped = wrap_svg(svg, width=20.0)
     assert "width: 20.0px" in wrapped
     assert svg in wrapped
 
@@ -49,7 +49,7 @@ def test_tagged_gates_to_placeholder_adds_error_and_mapping():
 
 def test_render_svg_wraps_when_width_given():
     c = stim.Circuit("I[R_Z(theta=0.25*pi)] 0")
-    html = str(render_svg(c, "timeline-svg", width=50))
+    html = str(render_svg(c, "timeline-svg", width=50, zoomable=False))
     assert "<div" in html
     assert "width: 50" in html
 

--- a/test/unit/utils/test_diagram.py
+++ b/test/unit/utils/test_diagram.py
@@ -49,7 +49,11 @@ def test_tagged_gates_to_placeholder_adds_error_and_mapping():
 
 def test_render_svg_wraps_when_width_given():
     c = stim.Circuit("I[R_Z(theta=0.25*pi)] 0")
-    html = str(render_svg(c, "timeline-svg", width=50, zoomable=False))
+    diagram = render_svg(c, "timeline-svg", width=50, zoomable=False)
+    # str() returns raw SVG suitable for saving to .svg files
+    assert str(diagram).strip().startswith("<svg")
+    # _repr_html_() returns the HTML-wrapped version for Jupyter
+    html = diagram._repr_html_()
     assert "<div" in html
     assert "width: 50" in html
 


### PR DESCRIPTION
This pull request adds interactive zoom and pan functionality to timeline and timeslice SVG diagrams generated by the `Circuit.diagram` method. It introduces a new `zoomable` option (enabled by default) for these diagram types, updates the rendering utilities to support zoomable containers, and improves handling of SVG sizing based on viewBox attributes.