### PR TITLE
Enhance measurement functions to support flip probability

### DIFF
--- a/src/tsim/core/instructions.py
+++ b/src/tsim/core/instructions.py
@@ -185,7 +185,7 @@ def i(b: GraphRepresentation, qubit: int, *_args: float) -> None:
     b.graph.set_row(v, last_row(b, qubit) + 1)
 
 
-def ii(b: GraphRepresentation, qubit1: int, qubit2: int) -> None:
+def ii(b: GraphRepresentation, qubit1: int, qubit2: int, *_args: float) -> None:
     """Apply two-qubit identity (advances the row on both qubits)."""
     i(b, qubit1)
     i(b, qubit2)
@@ -868,6 +868,7 @@ def mpp(
     b: GraphRepresentation,
     paulis: list[tuple[Literal["X", "Y", "Z"], int]],
     invert: bool = False,
+    p: float = 0,
 ) -> None:
     """Measure a single Pauli product.
 
@@ -875,6 +876,7 @@ def mpp(
         b: The graph representation to modify.
         paulis: List of (pauli_type, qubit) pairs defining the Pauli product.
         invert: Whether to invert the measurement result.
+        p: Measurement flip error probability.
 
     """
     aux = -2
@@ -882,7 +884,7 @@ def mpp(
     h(b, aux)
     _apply_pauli_controls(b, aux, paulis)
     h(b, aux)
-    m(b, aux, invert=invert)
+    m(b, aux, p=p, invert=invert)
 
 
 def _apply_pauli_controls(
@@ -1017,19 +1019,25 @@ def my(b: GraphRepresentation, qubit: int, p: float = 0, invert: bool = False) -
     h_yz(b, qubit)
 
 
-def mxx(b: GraphRepresentation, q0: int, q1: int, invert: bool = False) -> None:
+def mxx(
+    b: GraphRepresentation, q0: int, q1: int, p: float = 0, invert: bool = False
+) -> None:
     """Measure two qubits in XX basis."""
-    mpp(b, [("X", q0), ("X", q1)], invert)
+    mpp(b, [("X", q0), ("X", q1)], invert, p=p)
 
 
-def myy(b: GraphRepresentation, q0: int, q1: int, invert: bool = False) -> None:
+def myy(
+    b: GraphRepresentation, q0: int, q1: int, p: float = 0, invert: bool = False
+) -> None:
     """Measure two qubits in YY basis."""
-    mpp(b, [("Y", q0), ("Y", q1)], invert)
+    mpp(b, [("Y", q0), ("Y", q1)], invert, p=p)
 
 
-def mzz(b: GraphRepresentation, q0: int, q1: int, invert: bool = False) -> None:
+def mzz(
+    b: GraphRepresentation, q0: int, q1: int, p: float = 0, invert: bool = False
+) -> None:
     """Measure two qubits in ZZ basis."""
-    mpp(b, [("Z", q0), ("Z", q1)], invert)
+    mpp(b, [("Z", q0), ("Z", q1)], invert, p=p)
 
 
 def r(b: GraphRepresentation, qubit: int) -> None:

--- a/src/tsim/core/parse.py
+++ b/src/tsim/core/parse.py
@@ -149,8 +149,10 @@ def parse_stim_circuit(
             tick(b)
             continue
         if name == "MPP":
+            args = instruction.gate_args_copy()
+            p = args[0] if args else 0
             for paulis, invert in _iter_pauli_products(instruction):
-                mpp(b, paulis, invert)
+                mpp(b, paulis, invert, p=p)
             continue
         if name in ("SPP", "SPP_DAG"):
             is_dag = name == "SPP_DAG"

--- a/test/unit/core/test_parse.py
+++ b/test/unit/core/test_parse.py
@@ -150,6 +150,28 @@ class TestParseHeraldedChannels:
         assert len(b.channel_probs) == 3
 
 
+class TestParseIIError:
+    """Tests for parsing II_ERROR instructions with parenthesized arguments."""
+
+    def test_ii_error_with_probability(self):
+        """II_ERROR(p) should parse without raising a TypeError."""
+        circuit = stim.Circuit("II_ERROR(0.1) 0 1")
+        b = parse_stim_circuit(circuit)
+        assert set(b.last_vertex) == {0, 1}
+
+    def test_ii_error_without_probability(self):
+        """II_ERROR without parens should also parse correctly."""
+        circuit = stim.Circuit("II_ERROR 0 1")
+        b = parse_stim_circuit(circuit)
+        assert set(b.last_vertex) == {0, 1}
+
+    def test_ii_error_multiple_pairs(self):
+        """II_ERROR(p) applied to multiple qubit pairs."""
+        circuit = stim.Circuit("II_ERROR(0.05) 0 1 2 3")
+        b = parse_stim_circuit(circuit)
+        assert set(b.last_vertex) == {0, 1, 2, 3}
+
+
 class TestParseWithRepeatBlocks:
     """Tests for parsing circuits that contain REPEAT blocks."""
 
@@ -289,6 +311,48 @@ class TestParseMXXMYYMZZ:
         """)
         b = parse_stim_circuit(circuit)
         assert len(b.rec) == 3
+
+
+class TestParseMXXMYYMZZWithArgs:
+    """Tests for MXX/MYY/MZZ with parenthesized flip probability."""
+
+    def test_mxx_with_flip_probability(self):
+        """MXX(p) should parse without misinterpreting p as invert."""
+        circuit = stim.Circuit("MXX(0.01) 0 1")
+        b = parse_stim_circuit(circuit)
+        assert len(b.rec) == 1
+        assert_allclose(b.channel_probs[0], [0.99, 0.01])
+
+    def test_myy_with_flip_probability(self):
+        """MYY(p) should parse without misinterpreting p as invert."""
+        circuit = stim.Circuit("MYY(0.01) 0 1")
+        b = parse_stim_circuit(circuit)
+        assert len(b.rec) == 1
+        assert_allclose(b.channel_probs[0], [0.99, 0.01])
+
+    def test_mzz_with_flip_probability(self):
+        """MZZ(p) should parse without misinterpreting p as invert."""
+        circuit = stim.Circuit("MZZ(0.01) 0 1")
+        b = parse_stim_circuit(circuit)
+        assert len(b.rec) == 1
+        assert_allclose(b.channel_probs[0], [0.99, 0.01])
+
+    def test_mxx_flip_prob_multiple_pairs(self):
+        """MXX(p) with multiple pairs should work correctly."""
+        circuit = stim.Circuit("MXX(0.05) 0 1 2 3")
+        b = parse_stim_circuit(circuit)
+        assert len(b.rec) == 2
+
+
+class TestParseMPPWithArgs:
+    """Tests for MPP with parenthesized flip probability."""
+
+    def test_mpp_with_flip_probability(self):
+        """MPP(p) should parse and forward flip probability."""
+        circuit = stim.Circuit("MPP(0.01) X0*Z1")
+        b = parse_stim_circuit(circuit)
+        assert len(b.rec) == 1
+        assert_allclose(b.channel_probs[0], [0.99, 0.01])
 
 
 class TestParseSPP:


### PR DESCRIPTION
Updated the `ii`, `mpp`, `mxx`, `myy`, and `mzz` functions to accept an additional `p` parameter for measurement flip error probability. Adjusted the `parse_stim_circuit` function to correctly parse and forward this probability from circuit instructions. Added unit tests to ensure proper parsing and functionality for new and existing measurement instructions with flip probabilities.