### PR TITLE
Fold duplicate column ids in Channel simplification

### DIFF
--- a/src/tsim/core/instructions.py
+++ b/src/tsim/core/instructions.py
@@ -740,10 +740,10 @@ def heralded_pauli_channel_1(
     b.channel_probs.append(heralded_pauli_channel_1_probs(pi, px, py, pz))
     aux = -2
     r(b, aux)
-    _error(b, aux, b.vertex_type.X, f"e{b.num_error_bits}")
+    _error(b, aux, b.vertex_type.X, f"e{b.num_error_bits}")  # herald bit flip
     m(b, aux)
-    _error(b, qubit, b.vertex_type.Z, f"e{b.num_error_bits + 1}")
-    _error(b, qubit, b.vertex_type.X, f"e{b.num_error_bits + 2}")
+    _error(b, qubit, b.vertex_type.Z, f"e{b.num_error_bits + 1}")  # Z error bit
+    _error(b, qubit, b.vertex_type.X, f"e{b.num_error_bits + 2}")  # X error bit
     b.num_error_bits += 3
 
 

--- a/src/tsim/external/vec_sim/vec_sampler.py
+++ b/src/tsim/external/vec_sim/vec_sampler.py
@@ -12,7 +12,6 @@ Modifications:
 - Removed sinter dependency, modifyied T replacement logic.
 """
 
-import random
 from typing import Literal, Union, overload
 
 import numpy as np
@@ -23,11 +22,8 @@ from tsim.external.vec_sim import VecSim
 
 
 class VecSampler:
-    def __init__(
-        self, stim_circuit: stim.Circuit, sweep_bit_randomization: bool = False
-    ):
+    def __init__(self, stim_circuit: stim.Circuit):
         self.circuit = stim_circuit
-        self.sweep_bit_randomization = sweep_bit_randomization
 
     def sample(self, shots: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Sample the circuit and return the measurements, detectors, and observables."""
@@ -35,7 +31,6 @@ class VecSampler:
         for _ in range(shots):
             m, d, o = sample_circuit_with_vec_sim_return_data(
                 self.circuit,
-                self.sweep_bit_randomization,
             )
             measurements.append(m)
             detectors.append(d)
@@ -49,7 +44,6 @@ class VecSampler:
     def state_vector(self) -> np.ndarray:
         return sample_circuit_with_vec_sim_return_data(
             self.circuit,
-            self.sweep_bit_randomization,
             return_state_vector=True,
         )
 
@@ -57,7 +51,6 @@ class VecSampler:
 @overload
 def sample_circuit_with_vec_sim_return_data(
     circuit: stim.Circuit,
-    sweep_bit_randomization: bool,
     return_state_vector: Literal[False] = False,
 ) -> tuple[list[bool], list[bool], list[bool]]: ...
 
@@ -65,24 +58,19 @@ def sample_circuit_with_vec_sim_return_data(
 @overload
 def sample_circuit_with_vec_sim_return_data(
     circuit: stim.Circuit,
-    sweep_bit_randomization: bool,
     return_state_vector: Literal[True],
 ) -> np.ndarray: ...
 
 
 def sample_circuit_with_vec_sim_return_data(
     circuit: stim.Circuit,
-    sweep_bit_randomization: bool,
     return_state_vector: bool = False,
 ) -> Union[tuple[list[bool], list[bool], list[bool]], np.ndarray]:
     sim = VecSim()
     measurements = []
     detectors = []
     observables = []
-    sweep_bits = {
-        b: sweep_bit_randomization and random.random() < 0.5
-        for b in range(circuit.num_sweep_bits)
-    }
+    sweep_bits = {b: False for b in range(circuit.num_sweep_bits)}
     for q in range(circuit.num_qubits):
         sim.do_qalloc_z(q)
     for inst in circuit:

--- a/src/tsim/external/vec_sim/vec_sampler.py
+++ b/src/tsim/external/vec_sim/vec_sampler.py
@@ -9,7 +9,7 @@ Code dataset: https://doi.org/10.5281/zenodo.13777072
 Licensed under CC BY 4.0: https://creativecommons.org/licenses/by/4.0/
 
 Modifications:
-- Removed sinter dependency, modifyied T replacement logic.
+- Removed sinter dependency, modified T replacement logic.
 """
 
 from typing import Literal, Union, overload
@@ -70,7 +70,6 @@ def sample_circuit_with_vec_sim_return_data(
     measurements = []
     detectors = []
     observables = []
-    sweep_bits = {b: False for b in range(circuit.num_sweep_bits)}
     for q in range(circuit.num_qubits):
         sim.do_qalloc_z(q)
     for inst in circuit:
@@ -102,7 +101,6 @@ def sample_circuit_with_vec_sim_return_data(
         else:
             sim.do_stim_instruction(
                 inst,
-                sweep_bits=sweep_bits,
                 out_measurements=measurements,
                 out_detectors=detectors,
                 out_observables=observables,

--- a/src/tsim/external/vec_sim/vec_sim.py
+++ b/src/tsim/external/vec_sim/vec_sim.py
@@ -643,7 +643,6 @@ class VecSim:
         self,
         inst: stim.CircuitInstruction,
         *,
-        sweep_bits: dict[int, bool],
         out_measurements: list[bool],
         out_detectors: list[bool],
         out_observables: list[bool],
@@ -796,9 +795,6 @@ class VecSim:
                 if t1.is_measurement_record_target:
                     if out_measurements[t1.value]:
                         self.do_x(t2.qubit_value)
-                elif t1.is_sweep_bit_target:
-                    if sweep_bits[t1.value]:
-                        self.do_z(t2.qubit_value)
                 else:
                     self.do_cx(t1.qubit_value, t2.qubit_value)
         elif inst.name == "CZ":
@@ -810,12 +806,6 @@ class VecSim:
                         self.do_z(t2.qubit_value)
                 elif t2.is_measurement_record_target:
                     if out_measurements[t2.value]:
-                        self.do_z(t1.qubit_value)
-                elif t1.is_sweep_bit_target:
-                    if sweep_bits[t1.value]:
-                        self.do_z(t2.qubit_value)
-                elif t2.is_sweep_bit_target:
-                    if sweep_bits[t2.value]:
                         self.do_z(t1.qubit_value)
                 else:
                     self.do_cz(t1.qubit_value, t2.qubit_value)

--- a/src/tsim/noise/channels.py
+++ b/src/tsim/noise/channels.py
@@ -469,7 +469,7 @@ def absorb_subset_channels(channels: list[Channel], max_bits: int = 4) -> list[C
 def simplify_channels(
     channels: list[Channel], max_bits: int = 4, null_col_id: int | None = None
 ) -> list[Channel]:
-    """Simplify channels by removing null columns, merging identical and absorbing subsets.
+    """Simplify channels by removing null columns, folding, merging identical and absorbing subsets.
 
     Args:
         channels: List of channels to simplify
@@ -503,6 +503,7 @@ class ChannelSampler:
 
     Channels are automatically simplified by:
     1. Removing bits e_i that do not affect any f-variable (i.e. all-zero columns in error_transform)
+    2. Folding duplicate column IDs, i.e. channels whose column signatures contain duplicate IDs.
     2. Merging channels with identical column signatures, i.e. channels whose corresponding
         columns in error_transform are identical.
     3. Absorbing channels whose signatures are subsets of others, i.e. channels whose corresponding

--- a/src/tsim/noise/channels.py
+++ b/src/tsim/noise/channels.py
@@ -297,6 +297,46 @@ def normalize_channels(channels: list[Channel]) -> list[Channel]:
     return result
 
 
+def fold_duplicate_channel_bits(channels: list[Channel]) -> list[Channel]:
+    """Canonicalize channels by XOR-folding duplicate column IDs.
+
+    If two bits in the same channel have identical column signatures, sampling
+    both bits only affects the reduced error basis through their parity. This
+    replaces those duplicate bits with one bit whose probability is the sum of
+    all old outcomes with the same XOR-folded value.
+
+    Args:
+        channels: List of channels with sorted unique_col_ids
+
+    Returns:
+        List of channels whose unique_col_ids contain no duplicates
+
+    """
+    result: list[Channel] = []
+
+    for channel in channels:
+        old_col_ids = channel.unique_col_ids
+        new_col_ids = tuple(dict.fromkeys(old_col_ids))
+
+        if len(new_col_ids) == len(old_col_ids):
+            result.append(channel)
+            continue
+
+        col_to_new_pos = {col: pos for pos, col in enumerate(new_col_ids)}
+        new_probs = np.zeros(2 ** len(new_col_ids), dtype=np.float64)
+
+        for old_idx in range(len(channel.probs)):
+            new_idx = 0
+            for old_pos, col in enumerate(old_col_ids):
+                if (old_idx >> old_pos) & 1:
+                    new_idx ^= 1 << col_to_new_pos[col]
+            new_probs[new_idx] += channel.probs[old_idx]
+
+        result.append(Channel(probs=new_probs, unique_col_ids=new_col_ids))
+
+    return result
+
+
 def expand_channel(channel: Channel, target_col_ids: tuple[int, ...]) -> Channel:
     """Expand a channel's distribution to a larger signature set.
 
@@ -306,7 +346,8 @@ def expand_channel(channel: Channel, target_col_ids: tuple[int, ...]) -> Channel
 
     Duplicate source column IDs are allowed. When multiple source bits map to
     the same target bit, their contribution is XORed, matching GF(2)
-    composition.
+    composition. Duplicate target column IDs are not allowed; channels with
+    duplicate IDs should be canonicalized before subset absorption.
 
     Args:
         channel: Channel to expand (must have sorted unique_col_ids)
@@ -317,9 +358,14 @@ def expand_channel(channel: Channel, target_col_ids: tuple[int, ...]) -> Channel
 
     """
     source_col_ids = channel.unique_col_ids
-    assert source_col_ids == tuple(sorted(source_col_ids)), "Source must be sorted"
-    assert target_col_ids == tuple(sorted(target_col_ids)), "Target must be sorted"
-    assert set(source_col_ids) < set(target_col_ids), "Source must be strict subset"
+    if source_col_ids != tuple(sorted(source_col_ids)):
+        raise ValueError("Source must be sorted")
+    if target_col_ids != tuple(sorted(target_col_ids)):
+        raise ValueError("Target must be sorted")
+    if len(set(target_col_ids)) != len(target_col_ids):
+        raise ValueError("Target must not contain duplicates")
+    if not set(source_col_ids) < set(target_col_ids):
+        raise ValueError("Source must be strict subset")
 
     # Map source columns to their positions in target
     source_to_target = {s: target_col_ids.index(s) for s in source_col_ids}
@@ -437,6 +483,7 @@ def simplify_channels(
     """
     channels = reduce_null_bits(channels, null_col_id)
     channels = normalize_channels(channels)
+    channels = fold_duplicate_channel_bits(channels)
     channels = merge_identical_channels(channels)
     channels = absorb_subset_channels(channels, max_bits)
     return channels

--- a/src/tsim/noise/channels.py
+++ b/src/tsim/noise/channels.py
@@ -283,7 +283,7 @@ def expand_channel(channel: Channel, target_col_ids: tuple[int, ...]) -> Channel
         new_idx = 0
         for src_pos, src_col in enumerate(source_col_ids):
             if (old_idx >> src_pos) & 1:
-                new_idx |= 1 << source_to_target[src_col]
+                new_idx ^= 1 << source_to_target[src_col]
         new_probs[new_idx] += channel.probs[old_idx]
 
     return Channel(probs=new_probs, unique_col_ids=target_col_ids)

--- a/src/tsim/noise/channels.py
+++ b/src/tsim/noise/channels.py
@@ -12,9 +12,15 @@ import numpy as np
 class Channel:
     """A probability distribution over error outcomes.
 
+    Outcome indices: bit position ``i`` corresponds
+    to ``1 << i`` in ``probs``. For example, in a 2-bit channel, index 1
+    (0b01) is bit pattern ``bit0=1, bit1=0`` and index 2 (0b10) is
+    ``bit0=0, bit1=1``.
+
     Attributes:
-        probs: Shape (2^k,) probability array, sums to 1, dtype float64
-        unique_col_ids: Tuple of column IDs, where each ID corresponds to a bit of the channel.
+        probs: Shape ``(2**k,)`` probability array, sums to 1, dtype float64.
+        unique_col_ids: Tuple of column IDs. Entry ``i`` is the transform-column
+            signature affected by channel bit ``i``.
 
     """
 
@@ -28,7 +34,10 @@ class Channel:
 
 
 def error_probs(p: float) -> np.ndarray:
-    """Single-bit error channel. Returns shape (2,)."""
+    """Single-bit error channel.
+
+    Returns ``[P(bit0=0), P(bit0=1)]``.
+    """
     return np.array([1 - p, p], dtype=np.float64)
 
 
@@ -37,21 +46,39 @@ def heralded_pauli_channel_1_probs(
 ) -> np.ndarray:
     """Heralded single-qubit Pauli channel. Returns shape (8,).
 
-    Bits: [herald, Z_error, X_error].
+    Bit layout:
+    - bit 0: herald bit, written to the measurement record
+    - bit 1: Z error component
+    - bit 2: X error component
+
+    The non-zero outcomes are:
+    - index 0 (0b000): no herald, no Pauli error
+    - index 1 (0b001): herald + I
+    - index 3 (0b011): herald + Z
+    - index 5 (0b101): herald + X
+    - index 7 (0b111): herald + Y, represented as X+Z
     """
     probs = np.zeros(8, dtype=np.float64)
-    probs[0] = 1 - pi - px - py - pz  # 000, no fire
-    probs[1] = pi  # 100, herald, I
-    probs[3] = pz  # 110, herald + Z
-    probs[5] = px  # 101, herald + X
-    probs[7] = py  # 111, herald + Y (X+Z)
+    probs[0] = 1 - pi - px - py - pz
+    probs[1] = pi
+    probs[3] = pz
+    probs[5] = px
+    probs[7] = py
     return probs
 
 
 def pauli_channel_1_probs(px: float, py: float, pz: float) -> np.ndarray:
     """Single-qubit Pauli channel. Returns shape (4,).
 
-    Order: [I, Z, X, Y] mapped to bits [00, 01, 10, 11].
+    Bit layout:
+    - bit 0: Z error component
+    - bit 1: X error component
+
+    The outcomes are:
+    - index 0 (0b00): I
+    - index 1 (0b01): Z
+    - index 2 (0b10): X
+    - index 3 (0b11): Y
     """
     return np.array([1 - px - py - pz, pz, px, py], dtype=np.float64)
 
@@ -73,7 +100,19 @@ def pauli_channel_2_probs(
     pzy: float,
     pzz: float,
 ) -> np.ndarray:
-    """Two-qubit Pauli channel. Returns shape (16,)."""
+    """Two-qubit Pauli channel. Returns shape (16,).
+
+    Bit layout:
+    - bit 0: Z error component on ``qubit_i``
+    - bit 1: X error component on ``qubit_i``
+    - bit 2: Z error component on ``qubit_j``
+    - bit 3: X error component on ``qubit_j``
+
+    With that layout, index ``z_i + 2*x_i + 4*z_j + 8*x_j`` stores the
+    probability for the corresponding two-qubit Pauli outcome. The arguments
+    follow Stim's naming convention: ``pix`` is I on ``qubit_i`` and X on
+    ``qubit_j``, ``pzi`` is Z on ``qubit_i`` and I on ``qubit_j``, etc.
+    """
     remainder = (
         1
         - pix
@@ -94,22 +133,22 @@ def pauli_channel_2_probs(
     )
     probs = np.array(
         [
-            remainder,  # 00,00
-            pzi,  # 10,00
-            pxi,  # 01,00
-            pyi,  # 11,00
-            piz,  # 00,10
-            pzz,  # 10,10
-            pxz,  # 01,10
-            pyz,  # 11,10
-            pix,  # 00,01
-            pzx,  # 10,01
-            pxx,  # 01,01
-            pyx,  # 11,01
-            piy,  # 00,11
-            pzy,  # 10,11
-            pxy,  # 01,11
-            pyy,  # 11,11
+            remainder,  # index 0 (0b0000): II
+            pzi,  # index 1 (0b0001): ZI
+            pxi,  # index 2 (0b0010): XI
+            pyi,  # index 3 (0b0011): YI
+            piz,  # index 4 (0b0100): IZ
+            pzz,  # index 5 (0b0101): ZZ
+            pxz,  # index 6 (0b0110): XZ
+            pyz,  # index 7 (0b0111): YZ
+            pix,  # index 8 (0b1000): IX
+            pzx,  # index 9 (0b1001): ZX
+            pxx,  # index 10 (0b1010): XX
+            pyx,  # index 11 (0b1011): YX
+            piy,  # index 12 (0b1100): IY
+            pzy,  # index 13 (0b1101): ZY
+            pxy,  # index 14 (0b1110): XY
+            pyy,  # index 15 (0b1111): YY
         ],
         dtype=np.float64,
     )
@@ -124,9 +163,10 @@ def correlated_error_probs(probabilities: list[float]) -> np.ndarray:
     computes the joint probability distribution over 2^k outcomes.
 
     Since errors are mutually exclusive, only outcomes with at most one bit set
-    have non-zero probability:
-    - P(0) = (1-p1)(1-p2)...(1-pk)  (no error)
-    - P(2^i) = (1-p1)...(1-p_i) * p_{i+1}  (error i+1 occurred)
+    have non-zero probability.
+    - ``probs[0]`` is the probability that no branch fires.
+    - ``probs[1 << i]`` is the probability that branch ``i`` fires after all
+      previous branches did not fire.
 
     Args:
         probabilities: List of conditional probabilities [p1, p2, ..., pk]
@@ -213,7 +253,8 @@ def reduce_null_bits(
             # All entries are null, channel has no effect - remove it
             continue
 
-        # Marginalize out the null bits by summing over them
+        # Marginalize out null bits by summing their tensor axes. The Fortran
+        # order reshape makes axis i correspond to little-endian bit i.
         new_col_ids = tuple(channel.unique_col_ids[i] for i in non_null_positions)
         new_num_bits = len(non_null_positions)
         sum_axes = tuple(i for i in range(n) if i not in non_null_positions)
@@ -229,7 +270,9 @@ def normalize_channels(channels: list[Channel]) -> list[Channel]:
     """Normalize channels by sorting unique_col_ids, permuting probs accordingly.
 
     This ensures channels affecting the same set of columns have identical
-    unique_col_ids tuples, enabling merge_identical_channels to group them.
+    ``unique_col_ids`` tuples, enabling ``merge_identical_channels`` to group
+    them. The probability tensor is transposed using the same axis permutation
+    so little-endian outcome bits continue to refer to the matching column IDs.
 
     Args:
         channels: List of channels
@@ -257,8 +300,13 @@ def normalize_channels(channels: list[Channel]) -> list[Channel]:
 def expand_channel(channel: Channel, target_col_ids: tuple[int, ...]) -> Channel:
     """Expand a channel's distribution to a larger signature set.
 
-    The channel's existing col_ids must be a strict subset of target_col_ids.
-    Both must be sorted. New bit positions are treated as "don't care" (always 0).
+    The channel's existing column IDs must be a strict subset of
+    ``target_col_ids`` when considered as sets, and both tuples must be sorted.
+    New target bit positions are treated as always zero.
+
+    Duplicate source column IDs are allowed. When multiple source bits map to
+    the same target bit, their contribution is XORed, matching GF(2)
+    composition.
 
     Args:
         channel: Channel to expand (must have sorted unique_col_ids)
@@ -279,7 +327,8 @@ def expand_channel(channel: Channel, target_col_ids: tuple[int, ...]) -> Channel
     new_probs = np.zeros(2**n_target, dtype=np.float64)
 
     for old_idx in range(len(channel.probs)):
-        # Map old bit pattern to new bit pattern (new bits stay 0)
+        # Map old bit pattern to the expanded pattern.
+        # Use XOR so duplicate source columns cancel mod 2.
         new_idx = 0
         for src_pos, src_col in enumerate(source_col_ids):
             if (old_idx >> src_pos) & 1:
@@ -401,7 +450,9 @@ class ChannelSampler:
     "e" basis to a reduced "f" basis using geometric-skip sampling optimized for
     low-noise regimes.
 
-    f_i = error_transform_ij * e_j mod 2
+    ``f_i = error_transform_ij * e_j mod 2``. Within each channel,
+    probability-array bit 0 corresponds to the first produced error bit, bit 1
+    to the second, and so on.
 
     Channels are automatically simplified by:
     1. Removing bits e_i that do not affect any f-variable (i.e. all-zero columns in error_transform)

--- a/test/unit/core/test_parse.py
+++ b/test/unit/core/test_parse.py
@@ -1,8 +1,27 @@
+from collections import Counter
+
 import pytest
 import stim
 from numpy.testing import assert_allclose
+from pyzx_param.utils import VertexType
 
 from tsim.core.parse import parse_stim_circuit
+
+
+def _assert_error_vertex_layout(b, expected):
+    """Assert which ZX error vertices are controlled by each error bit."""
+    actual = {}
+    for v in b.graph.vertices():
+        for phase in b.graph._phaseVars.get(v, set()):
+            if isinstance(phase, str) and phase.startswith("e"):
+                actual.setdefault(phase, Counter()).update(
+                    [(b.graph.type(v), b.graph.qubit(v))]
+                )
+
+    expected_counters = {
+        phase: Counter(vertices) for phase, vertices in expected.items()
+    }
+    assert actual == expected_counters
 
 
 class TestParseCorrelatedError:
@@ -301,6 +320,123 @@ class TestProbabilityBearingInstructions:
 
         assert b.num_error_bits == 0
         assert len(b.channel_probs) == 0
+
+
+class TestChannelBitLayoutMatchesGraph:
+    """Tests tying channel probability bits to ZX error vertices."""
+
+    @pytest.mark.parametrize(
+        ("program", "expected_layout"),
+        [
+            ("X_ERROR(0.07) 5", {"e0": [(VertexType.X, 5)]}),
+            ("Y_ERROR(0.07) 5", {"e0": [(VertexType.Z, 5), (VertexType.X, 5)]}),
+            ("Z_ERROR(0.07) 5", {"e0": [(VertexType.Z, 5)]}),
+            ("M(0.07) 5", {"e0": [(VertexType.X, 5)]}),
+            ("MX(0.07) 5", {"e0": [(VertexType.X, 5)]}),
+            ("MY(0.07) 5", {"e0": [(VertexType.X, 5)]}),
+            ("MR(0.07) 5", {"e0": [(VertexType.X, 5)]}),
+            ("MRX(0.07) 5", {"e0": [(VertexType.X, 5)]}),
+            ("MRY(0.07) 5", {"e0": [(VertexType.X, 5)]}),
+            ("MXX(0.07) 5 7", {"e0": [(VertexType.X, -2)]}),
+            ("MPP(0.07) X5*Z7", {"e0": [(VertexType.X, -2)]}),
+            ("MPAD(0.07) 1", {"e0": [(VertexType.X, -2)]}),
+        ],
+    )
+    def test_single_bit_channel_layout_matches_graph(self, program, expected_layout):
+        """Single-bit channel index 1 (0b1) should control the expected vertex."""
+        b = parse_stim_circuit(stim.Circuit(program))
+
+        assert b.num_error_bits == 1
+        assert_allclose(b.channel_probs[0], [0.93, 0.07])
+        _assert_error_vertex_layout(b, expected_layout)
+
+    @pytest.mark.parametrize(
+        "program",
+        ["PAULI_CHANNEL_1(0.01, 0.02, 0.03) 5", "DEPOLARIZE1(0.12) 5"],
+    )
+    def test_pauli_channel_1_bit_layout_matches_graph(self, program):
+        """Index bit 0 is Z and index bit 1 is X for one-qubit Pauli channels."""
+        b = parse_stim_circuit(stim.Circuit(program))
+
+        assert b.num_error_bits == 2
+        _assert_error_vertex_layout(
+            b,
+            {
+                "e0": [(VertexType.Z, 5)],
+                "e1": [(VertexType.X, 5)],
+            },
+        )
+
+    @pytest.mark.parametrize(
+        "program",
+        [
+            "PAULI_CHANNEL_2("
+            "0.001, 0.002, 0.003, 0.004, 0.005, "
+            "0.006, 0.007, 0.008, 0.009, 0.010, "
+            "0.011, 0.012, 0.013, 0.014, 0.015"
+            ") 5 7",
+            "DEPOLARIZE2(0.15) 5 7",
+        ],
+    )
+    def test_pauli_channel_2_bit_layout_matches_graph(self, program):
+        """Bits are Z_i, X_i, Z_j, X_j for two-qubit Pauli channels."""
+        b = parse_stim_circuit(stim.Circuit(program))
+
+        assert b.num_error_bits == 4
+        _assert_error_vertex_layout(
+            b,
+            {
+                "e0": [(VertexType.Z, 5)],
+                "e1": [(VertexType.X, 5)],
+                "e2": [(VertexType.Z, 7)],
+                "e3": [(VertexType.X, 7)],
+            },
+        )
+
+    @pytest.mark.parametrize(
+        "program",
+        [
+            "HERALDED_PAULI_CHANNEL_1(0.01, 0.02, 0.03, 0.04) 5",
+            "HERALDED_ERASE(0.2) 5",
+        ],
+    )
+    def test_heralded_channel_bit_layout_matches_graph(self, program):
+        """Bits are herald, Z, X for heralded one-qubit Pauli channels."""
+        b = parse_stim_circuit(stim.Circuit(program))
+
+        assert len(b.rec) == 1
+        assert b.num_error_bits == 3
+        _assert_error_vertex_layout(
+            b,
+            {
+                "e0": [(VertexType.X, -2)],
+                "e1": [(VertexType.Z, 5)],
+                "e2": [(VertexType.X, 5)],
+            },
+        )
+
+    def test_correlated_error_bit_layout_matches_graph(self):
+        """Each correlated-error branch controls its matching Pauli vertices."""
+        circuit = stim.Circuit("""
+            CORRELATED_ERROR(0.1) X5 Y6 Z7
+            ELSE_CORRELATED_ERROR(0.2) Z5
+        """)
+        b = parse_stim_circuit(circuit)
+
+        assert b.num_error_bits == 2
+        assert_allclose(b.channel_probs[0], [0.72, 0.1, 0.18, 0.0])
+        _assert_error_vertex_layout(
+            b,
+            {
+                "e0": [
+                    (VertexType.X, 5),
+                    (VertexType.Z, 6),
+                    (VertexType.X, 6),
+                    (VertexType.Z, 7),
+                ],
+                "e1": [(VertexType.Z, 5)],
+            },
+        )
 
 
 class TestParseIIError:

--- a/test/unit/external/test_vec_sampler.py
+++ b/test/unit/external/test_vec_sampler.py
@@ -15,7 +15,7 @@ def test_vec_sampler_bell_state():
         DETECTOR rec[-1] rec[-2]
         """)
     random.seed(0)
-    sampler = VecSampler(c, False)
+    sampler = VecSampler(c)
     m, d, _ = sampler.sample(10)
 
     assert np.array_equal(m[:, 0], m[:, 1])
@@ -32,7 +32,7 @@ def test_vec_sampler_bell_state_with_measurement_error():
         M 0 1
         DETECTOR rec[-1] rec[-2]
         """)
-    sampler = VecSampler(c, False)
+    sampler = VecSampler(c)
 
     random.seed(0)
     _, d, _ = sampler.sample(10)
@@ -47,7 +47,7 @@ def test_t_gate():
         M 0
         """)
     random.seed(0)
-    sampler = VecSampler(c, False)
+    sampler = VecSampler(c)
     m, _, _ = sampler.sample(100)
     assert np.count_nonzero(m) == 12
 
@@ -60,7 +60,7 @@ def test_s_gate():
         M 0
         """)
     random.seed(0)
-    sampler = VecSampler(c, False)
+    sampler = VecSampler(c)
     m, _, _ = sampler.sample(100)
     assert np.count_nonzero(m) == 42
 
@@ -74,7 +74,7 @@ def test_t_dag_gate():
         M 0
         """)
     random.seed(0)
-    sampler = VecSampler(c, False)
+    sampler = VecSampler(c)
     m, _, _ = sampler.sample(10)
     assert np.count_nonzero(m) == 0
 
@@ -88,6 +88,6 @@ def test_s_dag_gate():
         M 0
         """)
     random.seed(0)
-    sampler = VecSampler(c, False)
+    sampler = VecSampler(c)
     m, _, _ = sampler.sample(10)
     assert np.count_nonzero(m) == 0

--- a/test/unit/noise/test_channels.py
+++ b/test/unit/noise/test_channels.py
@@ -325,12 +325,82 @@ class TestExpandChannel:
         expanded = expand_channel(c, (3, 5))
 
         assert expanded.unique_col_ids == (3, 5)
-        # Signature 5 is at position 1 in target, so bit 1 has the probability
-        # Bit 0 (signature 3) is always 0
-        assert_allclose(expanded.probs[0], 0.7, rtol=1e-5)  # 0b00
-        assert_allclose(expanded.probs[1], 0.0, rtol=1e-5)  # 0b01
-        assert_allclose(expanded.probs[2], 0.3, rtol=1e-5)  # 0b10
-        assert_allclose(expanded.probs[3], 0.0, rtol=1e-5)  # 0b11
+        assert expanded.num_bits == 2
+        assert_allclose(expanded.probs, expected)
+
+    @pytest.mark.parametrize("unique_col_id", [3, 4, 5])
+    def test_expand_1bit_to_3bit(self, unique_col_id):
+        """Expand a 1-bit channel to a 3-bit signature set."""
+        target_col_ids = (3, 4, 5)
+        c = Channel(probs=error_probs(0.3), unique_col_ids=(unique_col_id,))
+
+        expanded = expand_channel(c, target_col_ids)
+
+        expected = np.zeros(8, dtype=np.float64)
+        expected[0b000] = 0.7
+        expected[1 << target_col_ids.index(unique_col_id)] = 0.3
+        assert expanded.unique_col_ids == target_col_ids
+        assert expanded.num_bits == 3
+        assert_allclose(expanded.probs, expected)
+
+    @pytest.mark.parametrize("unique_col_id", [3, 4, 5, 6, 7])
+    def test_expand_1bit_to_5bit(self, unique_col_id):
+        """Expand a 1-bit channel to a 5-bit signature set."""
+        target_col_ids = (3, 4, 5, 6, 7)
+        c = Channel(probs=error_probs(0.3), unique_col_ids=(unique_col_id,))
+
+        expanded = expand_channel(c, target_col_ids)
+
+        expected = np.zeros(32, dtype=np.float64)
+        expected[0b00000] = 0.7
+        expected[1 << target_col_ids.index(unique_col_id)] = 0.3
+        assert expanded.unique_col_ids == target_col_ids
+        assert expanded.num_bits == 5
+        assert_allclose(expanded.probs, expected)
+
+    @pytest.mark.parametrize("source_col_ids", [(0, 1), (0, 3), (1, 3), (2, 3)])
+    def test_expand_2bit_to_4bit_preserves_source_bit_positions(self, source_col_ids):
+        """Expand a 2-bit channel into non-adjacent target signature positions."""
+        probs = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float64)
+        target_col_ids = (0, 1, 2, 3)
+        c = Channel(probs=probs, unique_col_ids=source_col_ids)
+
+        expanded = expand_channel(c, target_col_ids)
+
+        expected = np.zeros(16, dtype=np.float64)
+        expected[0b0000] = 0.1
+        expected[1 << target_col_ids.index(source_col_ids[0])] = 0.2
+        expected[1 << target_col_ids.index(source_col_ids[1])] = 0.3
+        expected[
+            (1 << target_col_ids.index(source_col_ids[0]))
+            | (1 << target_col_ids.index(source_col_ids[1]))
+        ] = 0.4
+        assert expanded.unique_col_ids == target_col_ids
+        assert expanded.num_bits == 4
+        assert_allclose(expanded.probs, expected)
+
+    def test_expand_duplicate_source_col_ids_cancel_mod_2(self):
+        """Duplicate source column bits should combine by XOR, not OR."""
+        # Bits 0 and 1 both map to target column 0. Outcomes 00 and 11 map to
+        # target bit 0, while 01 and 10 map to target bit 1.
+        probs = np.array([0.1, 0.2, 0.4, 0.3], dtype=np.float64)
+        c = Channel(probs=probs, unique_col_ids=(0, 0))
+
+        expanded = expand_channel(c, (0, 1))
+
+        assert expanded.unique_col_ids == (0, 1)
+        assert_allclose(expanded.probs, [0.4, 0.6, 0.0, 0.0])
+
+    def test_expand_deterministic_duplicate_bits_cancel_to_identity(self):
+        """A deterministic 11 outcome on duplicate columns should become 00."""
+        c = Channel(
+            probs=np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float64),
+            unique_col_ids=(0, 0),
+        )
+
+        expanded = expand_channel(c, (0, 1))
+
+        assert_allclose(expanded.probs, [1.0, 0.0, 0.0, 0.0])
 
 
 class TestNormalizeChannels:
@@ -458,6 +528,23 @@ class TestAbsorbSubsetChannels:
 
         assert len(absorbed) == 1
         assert_sampling_matches(mat, channels, absorbed)
+
+    def test_absorb_duplicate_subset_channel_uses_xor_expansion(self):
+        """A duplicate-signature subset should cancel when absorbed into a superset."""
+        superset = Channel(
+            probs=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+            unique_col_ids=(0, 1),
+        )
+        duplicate_subset = Channel(
+            probs=np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float64),
+            unique_col_ids=(0, 0),
+        )
+
+        absorbed = absorb_subset_channels([superset, duplicate_subset])
+
+        assert len(absorbed) == 1
+        assert absorbed[0].unique_col_ids == (0, 1)
+        assert_allclose(absorbed[0].probs, [1.0, 0.0, 0.0, 0.0])
 
 
 class TestSimplifyChannels:

--- a/test/unit/noise/test_channels.py
+++ b/test/unit/noise/test_channels.py
@@ -9,6 +9,7 @@ from tsim.noise.channels import (
     correlated_error_probs,
     error_probs,
     expand_channel,
+    fold_duplicate_channel_bits,
     heralded_pauli_channel_1_probs,
     merge_identical_channels,
     normalize_channels,
@@ -385,7 +386,7 @@ class TestExpandChannel:
     def test_expand_duplicate_source_col_ids_cancel_mod_2(self):
         """Duplicate source column bits should combine by XOR, not OR."""
         # Bits 0 and 1 both map to target column 0. Outcomes 00 and 11 map to
-        # target bit 0, while 01 and 10 map to target bit 1.
+        # target index 0b00, while 01 and 10 map to target index 0b01.
         probs = np.array([0.1, 0.2, 0.4, 0.3], dtype=np.float64)
         c = Channel(probs=probs, unique_col_ids=(0, 0))
 
@@ -404,6 +405,161 @@ class TestExpandChannel:
         expanded = expand_channel(c, (0, 1))
 
         assert_allclose(expanded.probs, [1.0, 0.0, 0.0, 0.0])
+
+    def test_expand_rejects_duplicate_target_col_ids(self):
+        """Target signature sets must not contain duplicate column IDs."""
+        c = Channel(probs=error_probs(0.3), unique_col_ids=(0,))
+
+        with pytest.raises(ValueError, match="Target must not contain duplicates"):
+            expand_channel(c, (0, 1, 1))
+
+    def test_expand_rejects_unsorted_source_col_ids(self):
+        """Source signature sets must be sorted."""
+        c = Channel(
+            probs=np.array([0.7, 0.1, 0.1, 0.1], dtype=np.float64),
+            unique_col_ids=(1, 0),
+        )
+
+        with pytest.raises(ValueError, match="Source must be sorted"):
+            expand_channel(c, (0, 1, 2))
+
+    def test_expand_rejects_unsorted_target_col_ids(self):
+        """Target signature sets must be sorted."""
+        c = Channel(probs=error_probs(0.3), unique_col_ids=(0,))
+
+        with pytest.raises(ValueError, match="Target must be sorted"):
+            expand_channel(c, (1, 0))
+
+    @pytest.mark.parametrize("target_col_ids", [(0,), (1, 2)])
+    def test_expand_rejects_target_that_is_not_strict_superset(self, target_col_ids):
+        """Target signature sets must strictly contain all source column IDs."""
+        c = Channel(probs=error_probs(0.3), unique_col_ids=(0,))
+
+        with pytest.raises(ValueError, match="Source must be strict subset"):
+            expand_channel(c, target_col_ids)
+
+
+class TestFoldDuplicateChannelBits:
+    """Tests for fold_duplicate_channel_bits."""
+
+    def test_fold_two_duplicate_bits_by_xor(self):
+        """Duplicate bits with one column ID become one parity bit."""
+        c = Channel(
+            probs=np.array([0.1, 0.2, 0.4, 0.3], dtype=np.float64),
+            unique_col_ids=(0, 0),
+        )
+
+        folded = fold_duplicate_channel_bits([c])
+
+        assert len(folded) == 1
+        assert folded[0].unique_col_ids == (0,)
+        assert_allclose(folded[0].probs, [0.4, 0.6])
+
+    def test_simplify_folds_duplicate_bits_before_absorption(self):
+        """Subset absorption should only expand into duplicate-free targets."""
+        channels = [
+            Channel(
+                probs=np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float64),
+                unique_col_ids=(0, 0),
+            ),
+            Channel(probs=error_probs(0.3), unique_col_ids=(0,)),
+        ]
+
+        simplified = simplify_channels(channels)
+
+        assert len(simplified) == 1
+        assert simplified[0].unique_col_ids == (0,)
+
+    def test_no_duplicates_pass_through(self):
+        """A channel with no duplicate col_ids should be returned unchanged."""
+        probs = np.array([0.5, 0.2, 0.2, 0.1], dtype=np.float64)
+        c = Channel(probs=probs, unique_col_ids=(0, 1))
+
+        folded = fold_duplicate_channel_bits([c])
+
+        assert len(folded) == 1
+        assert folded[0].unique_col_ids == (0, 1)
+        assert_allclose(folded[0].probs, probs)
+
+    def test_empty_list_returns_empty(self):
+        """An empty input list should return an empty list."""
+        assert fold_duplicate_channel_bits([]) == []
+
+    def test_fold_three_duplicate_bits_by_parity(self):
+        """Three bits sharing one column ID should fold to one parity bit."""
+        # col_ids (0, 0, 0): all three bits map to col 0. The fold collects the
+        # mass of even-parity old indices into new[0] and odd-parity into new[1].
+        probs = np.arange(1, 9, dtype=np.float64)
+        probs /= probs.sum()
+        c = Channel(probs=probs, unique_col_ids=(0, 0, 0))
+
+        folded = fold_duplicate_channel_bits([c])
+
+        assert len(folded) == 1
+        assert folded[0].unique_col_ids == (0,)
+        even_sum = probs[0] + probs[3] + probs[5] + probs[6]  # 000, 011, 101, 110
+        odd_sum = probs[1] + probs[2] + probs[4] + probs[7]  # 001, 010, 100, 111
+        assert_allclose(folded[0].probs, [even_sum, odd_sum])
+
+    def test_fold_partial_duplicates(self):
+        """Only-duplicate bits should fold; unique bits should be preserved."""
+        # col_ids (0, 0, 1): bits 0 and 1 fold onto new pos 0,
+        # bit 2 maps to new pos 1.
+        probs = np.arange(1, 9, dtype=np.float64)
+        probs /= probs.sum()
+        c = Channel(probs=probs, unique_col_ids=(0, 0, 1))
+
+        folded = fold_duplicate_channel_bits([c])
+
+        assert len(folded) == 1
+        assert folded[0].unique_col_ids == (0, 1)
+        expected = np.zeros(4, dtype=np.float64)
+        expected[0b00] = probs[0b000] + probs[0b011]
+        expected[0b01] = probs[0b001] + probs[0b010]
+        expected[0b10] = probs[0b100] + probs[0b111]
+        expected[0b11] = probs[0b101] + probs[0b110]
+        assert_allclose(folded[0].probs, expected)
+
+    def test_fold_preserves_probability_mass(self):
+        """Folded channel should still sum to 1."""
+        probs = np.array([0.1, 0.2, 0.4, 0.3], dtype=np.float64)
+        c = Channel(probs=probs, unique_col_ids=(0, 0))
+
+        folded = fold_duplicate_channel_bits([c])
+
+        assert_allclose(np.sum(folded[0].probs), 1.0)
+
+    def test_fold_multiple_channels_mixed(self):
+        """A list mixing folded and unchanged channels should process each in place."""
+        c1 = Channel(
+            probs=np.array([0.1, 0.2, 0.4, 0.3], dtype=np.float64),
+            unique_col_ids=(0, 0),
+        )
+        c2 = Channel(probs=error_probs(0.25), unique_col_ids=(1,))
+        c3 = Channel(
+            probs=np.array([0.5, 0.1, 0.3, 0.1], dtype=np.float64),
+            unique_col_ids=(2, 3),
+        )
+
+        folded = fold_duplicate_channel_bits([c1, c2, c3])
+
+        assert len(folded) == 3
+        assert folded[0].unique_col_ids == (0,)
+        assert_allclose(folded[0].probs, [0.4, 0.6])
+        assert folded[1].unique_col_ids == (1,)
+        assert_allclose(folded[1].probs, c2.probs)
+        assert folded[2].unique_col_ids == (2, 3)
+        assert_allclose(folded[2].probs, c3.probs)
+
+    def test_fold_preserves_sampling_statistics(self):
+        """Sampling stats should match before and after folding duplicate bits."""
+        mat = np.array([[1, 0], [0, 1]], dtype=np.uint8)
+        probs = np.array([0.2, 0.1, 0.15, 0.05, 0.2, 0.1, 0.1, 0.1], dtype=np.float64)
+        c = Channel(probs=probs, unique_col_ids=(0, 0, 1))
+
+        folded = fold_duplicate_channel_bits([c])
+
+        assert_sampling_matches(mat, [c], folded)
 
 
 class TestNormalizeChannels:

--- a/test/unit/noise/test_channels.py
+++ b/test/unit/noise/test_channels.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
 from tsim.noise.channels import (
@@ -38,15 +39,15 @@ class TestProbabilityConstructors:
         assert probs.shape == (4,)
         assert probs.dtype == np.float64
         # Order: [I, Z, X, Y] mapped to bits [00, 01, 10, 11]
-        assert_allclose(probs[2], 1.0, rtol=1e-10)  # X = 10
+        assert_allclose(probs[2], 1.0, rtol=1e-10)  # index 2 (0b10): X
 
         # Pure Y error
         probs = pauli_channel_1_probs(px=0.0, py=1.0, pz=0.0)
-        assert_allclose(probs[3], 1.0, rtol=1e-10)  # Y = 11
+        assert_allclose(probs[3], 1.0, rtol=1e-10)  # index 3 (0b11): Y
 
         # Pure Z error
         probs = pauli_channel_1_probs(px=0.0, py=0.0, pz=1.0)
-        assert_allclose(probs[1], 1.0, rtol=1e-10)  # Z = 01
+        assert_allclose(probs[1], 1.0, rtol=1e-10)  # index 1 (0b01): Z
 
     def test_pauli_channel_2(self):
         """Test two-qubit Pauli channel."""
@@ -70,7 +71,7 @@ class TestProbabilityConstructors:
         )
         assert probs.shape == (16,)
         assert probs.dtype == np.float64
-        assert_allclose(probs[8], 1.0, rtol=1e-10)  # IX = 0100 in 4-bit = 8
+        assert_allclose(probs[8], 1.0, rtol=1e-10)  # index 8 (0b1000): IX
         assert_allclose(np.sum(probs), 1.0, rtol=1e-10)
 
     def test_heralded_pauli_channel_1(self):
@@ -78,21 +79,21 @@ class TestProbabilityConstructors:
         probs = heralded_pauli_channel_1_probs(pi=0.01, px=0.02, py=0.03, pz=0.04)
         assert probs.shape == (8,)
         assert probs.dtype == np.float64
-        # Bits: [herald, Z_error, X_error]
-        assert_allclose(probs[0], 0.9)  # 000: no fire
-        assert_allclose(probs[1], 0.01)  # 001: herald + I
-        assert_allclose(probs[3], 0.04)  # 011: herald + Z
-        assert_allclose(probs[5], 0.02)  # 101: herald + X
-        assert_allclose(probs[7], 0.03)  # 111: herald + Y
-        assert_allclose(probs[2], 0.0)  # impossible
-        assert_allclose(probs[4], 0.0)  # impossible
-        assert_allclose(probs[6], 0.0)  # impossible
+        # Little-endian bits: bit0=herald, bit1=Z error, bit2=X error.
+        assert_allclose(probs[0], 0.9)  # index 0 (0b000): no fire
+        assert_allclose(probs[1], 0.01)  # index 1 (0b001): herald + I
+        assert_allclose(probs[3], 0.04)  # index 3 (0b011): herald + Z
+        assert_allclose(probs[5], 0.02)  # index 5 (0b101): herald + X
+        assert_allclose(probs[7], 0.03)  # index 7 (0b111): herald + Y
+        assert_allclose(probs[2], 0.0)  # index 2 (0b010): impossible
+        assert_allclose(probs[4], 0.0)  # index 4 (0b100): impossible
+        assert_allclose(probs[6], 0.0)  # index 6 (0b110): impossible
         assert_allclose(np.sum(probs), 1.0, rtol=1e-10)
 
     def test_heralded_pauli_channel_1_pure_z(self):
         """Heralded channel that always fires with Z."""
         probs = heralded_pauli_channel_1_probs(pi=0.0, px=0.0, py=0.0, pz=1.0)
-        assert_allclose(probs[3], 1.0)  # herald + Z
+        assert_allclose(probs[3], 1.0)  # index 3 (0b011): herald + Z
         assert_allclose(np.sum(probs), 1.0, rtol=1e-10)
 
 
@@ -103,8 +104,8 @@ class TestCorrelatedErrorProbs:
         """Single error with probability p."""
         probs = correlated_error_probs([0.3])
         assert probs.shape == (2,)
-        assert_allclose(probs[0], 0.7)  # No error
-        assert_allclose(probs[1], 0.3)  # Error occurred
+        assert_allclose(probs[0], 0.7)  # index 0 (0b0): no error
+        assert_allclose(probs[1], 0.3)  # index 1 (0b1): error occurred
         assert_allclose(np.sum(probs), 1.0)
 
     def test_two_errors(self):
@@ -127,10 +128,10 @@ class TestCorrelatedErrorProbs:
         # P1 = 0.2, P2 = 0.8*0.25 = 0.2, P3 = 0.8*0.75*0.333... = 0.2
         probs = correlated_error_probs([0.2, 0.25, 1 / 3])
         assert probs.shape == (8,)
-        assert_allclose(probs[0], 0.4, rtol=1e-5)  # No error: 40%
-        assert_allclose(probs[1], 0.2, rtol=1e-5)  # First: 20%
-        assert_allclose(probs[2], 0.2, rtol=1e-5)  # Second: 20%
-        assert_allclose(probs[4], 0.2, rtol=1e-5)  # Third: 20%
+        assert_allclose(probs[0], 0.4, rtol=1e-5)  # index 0 (0b000): no error
+        assert_allclose(probs[1], 0.2, rtol=1e-5)  # index 1 (0b001): first
+        assert_allclose(probs[2], 0.2, rtol=1e-5)  # index 2 (0b010): second
+        assert_allclose(probs[4], 0.2, rtol=1e-5)  # index 4 (0b100): third
         # All multi-bit outcomes are 0
         assert_allclose(probs[3], 0.0)
         assert_allclose(probs[5], 0.0)
@@ -154,10 +155,10 @@ class TestCorrelatedErrorProbs:
         """If first error is certain, subsequent errors have 0 probability."""
         probs = correlated_error_probs([1.0, 0.5, 0.5])
         assert probs.shape == (8,)
-        assert_allclose(probs[0], 0.0)  # No error
-        assert_allclose(probs[1], 1.0)  # First error (certain)
-        assert_allclose(probs[2], 0.0)  # Second error (blocked)
-        assert_allclose(probs[4], 0.0)  # Third error (blocked)
+        assert_allclose(probs[0], 0.0)  # index 0 (0b000): no error
+        assert_allclose(probs[1], 1.0)  # index 1 (0b001): first error
+        assert_allclose(probs[2], 0.0)  # index 2 (0b010): second error
+        assert_allclose(probs[4], 0.0)  # index 4 (0b100): third error
 
 
 def _sample_channels(channels, matrix, n_samples, seed=42):
@@ -310,13 +311,12 @@ class TestExpandChannel:
 
         expanded = expand_channel(c, (0, 1))
 
+        expected = np.zeros(4, dtype=np.float64)
+        expected[0b00] = 0.7
+        expected[0b01] = 0.3
         assert expanded.unique_col_ids == (0, 1)
         assert expanded.num_bits == 2
-        # Bit 1 is always 0, so only outcomes 0b00 and 0b01 have probability
-        assert_allclose(expanded.probs[0], 0.7, rtol=1e-5)  # 0b00
-        assert_allclose(expanded.probs[1], 0.3, rtol=1e-5)  # 0b01
-        assert_allclose(expanded.probs[2], 0.0, rtol=1e-5)  # 0b10
-        assert_allclose(expanded.probs[3], 0.0, rtol=1e-5)  # 0b11
+        assert_allclose(expanded.probs, expected)
 
     def test_expand_1bit_to_2bit_different_position(self):
         """Expand 1-bit channel to 2-bit where source is in second position."""
@@ -324,6 +324,9 @@ class TestExpandChannel:
 
         expanded = expand_channel(c, (3, 5))
 
+        expected = np.zeros(4, dtype=np.float64)
+        expected[0b00] = 0.7
+        expected[0b10] = 0.3
         assert expanded.unique_col_ids == (3, 5)
         assert expanded.num_bits == 2
         assert_allclose(expanded.probs, expected)
@@ -420,7 +423,7 @@ class TestNormalizeChannels:
 
     def test_2bit_reorder(self):
         """A 2-bit channel with reversed col_ids should be reordered."""
-        # probs[0] = P(00), probs[1] = P(01), probs[2] = P(10), probs[3] = P(11)
+        # Little-endian indices: bit0 contributes 1, bit1 contributes 2.
         # With col_ids (1, 0): bit 0 -> col 1, bit 1 -> col 0
         probs = np.array([0.5, 0.2, 0.2, 0.1], dtype=np.float64)
         c = Channel(probs=probs, unique_col_ids=(1, 0))
@@ -431,15 +434,15 @@ class TestNormalizeChannels:
         assert result[0].unique_col_ids == (0, 1)
         # After normalization to (0, 1): bit 0 -> col 0, bit 1 -> col 1
         # new[0] = old[0] (00 -> 00)
-        # new[1] = old[2] (01 in new = col0=1 = old bit1=1 -> old index 10)
-        # new[2] = old[1] (10 in new = col1=1 = old bit0=1 -> old index 01)
+        # new[1] (0b01) = old[2] (0b10): col0=1 means old bit1=1
+        # new[2] (0b10) = old[1] (0b01): col1=1 means old bit0=1
         # new[3] = old[3] (11 -> 11)
         expected = np.array([0.5, 0.2, 0.2, 0.1], dtype=np.float64)
         assert_allclose(result[0].probs, expected)
 
     def test_3bit_reorder(self):
         """A 3-bit channel with unsorted col_ids should be reordered correctly."""
-        # col_ids (2, 0, 1): bit 0 -> col 2, bit 1 -> col 0, bit 2 -> col 1
+        # With col_ids (2, 0, 1): bit 0 -> col 2, bit 1 -> col 0, bit 2 -> col 1.
         probs = np.array([0.4, 0.1, 0.15, 0.05, 0.1, 0.05, 0.1, 0.05], dtype=np.float64)
         c = Channel(probs=probs, unique_col_ids=(2, 0, 1))
 
@@ -682,7 +685,7 @@ class TestReduceNullBits:
 
     def test_2bit_one_null_marginalize(self):
         """A 2-bit channel with one null should reduce to 1-bit."""
-        # probs: [P(00), P(01), P(10), P(11)] = [0.4, 0.3, 0.2, 0.1]
+        # Little-endian probs: [P(00), P(bit0), P(bit1), P(bit0+bit1)].
         probs = np.array([0.4, 0.3, 0.2, 0.1], dtype=np.float64)
         c = Channel(probs=probs, unique_col_ids=(0, self.NULL))
         channels = [c]
@@ -700,7 +703,7 @@ class TestReduceNullBits:
 
     def test_2bit_first_null_marginalize(self):
         """A 2-bit channel with null in first position should marginalize correctly."""
-        # probs: [P(00), P(01), P(10), P(11)] = [0.4, 0.3, 0.2, 0.1]
+        # Little-endian probs: [P(00), P(bit0), P(bit1), P(bit0+bit1)].
         probs = np.array([0.4, 0.3, 0.2, 0.1], dtype=np.float64)
         c = Channel(probs=probs, unique_col_ids=(self.NULL, 5))
         channels = [c]
@@ -732,7 +735,7 @@ class TestReduceNullBits:
 
     def test_3bit_one_null_marginalize(self):
         """A 3-bit channel with one null should reduce to 2-bit."""
-        # 8 outcomes: 000, 001, 010, 011, 100, 101, 110, 111
+        # 8 little-endian outcomes, where bit i contributes index 1 << i.
         probs = np.array([0.2, 0.1, 0.15, 0.05, 0.2, 0.1, 0.1, 0.1], dtype=np.float64)
         c = Channel(probs=probs, unique_col_ids=(0, self.NULL, 2))
         channels = [c]


### PR DESCRIPTION
## Summary
- Add new duplicate column id folding step to simplify channels before merging
- Fix channel expansion so duplicate column IDs combine with GF(2) XOR semantics
- Clarify channel bit-layout documentation and comments
- Add tests tying probability-array bit layout to the ZX error vertices produced by parsing