### PR TITLE
Fix DEM rec-index shift for MXX/MYY/MZZ/MPAD

### DIFF
--- a/src/tsim/noise/dem.py
+++ b/src/tsim/noise/dem.py
@@ -113,14 +113,17 @@ def get_detector_error_model(
         assert not isinstance(instruction, stim.CircuitRepeatBlock)
         if instruction.name in [
             "M",
-            "MPP",
-            "MR",
-            "MRX",
-            "MRY",
-            "MRX",
             "MX",
             "MY",
             "MZ",
+            "MR",
+            "MRX",
+            "MRY",
+            "MXX",
+            "MYY",
+            "MZZ",
+            "MPP",
+            "MPAD",
         ]:
             targets = instruction.targets_copy()
             if instruction.name == "MPP":
@@ -129,6 +132,10 @@ def get_detector_error_model(
                 # num_measurements = num_non_combiner_targets - num_combiners
                 num_combiners = sum(1 for t in targets if t.is_combiner)
                 num_meas = len(targets) - 2 * num_combiners
+            elif instruction.name in ("MXX", "MYY", "MZZ"):
+                # Pair measurements: targets are listed in pairs and each pair
+                # produces a single measurement record.
+                num_meas = len(targets) // 2
             else:
                 num_meas = len(targets)
             for idx in obs:

--- a/src/tsim/noise/dem.py
+++ b/src/tsim/noise/dem.py
@@ -111,33 +111,12 @@ def get_detector_error_model(
 
     for instruction in stim_circuit.flattened():
         assert not isinstance(instruction, stim.CircuitRepeatBlock)
-        if instruction.name in [
-            "M",
-            "MX",
-            "MY",
-            "MZ",
-            "MR",
-            "MRX",
-            "MRY",
-            "MXX",
-            "MYY",
-            "MZZ",
-            "MPP",
-            "MPAD",
-        ]:
-            targets = instruction.targets_copy()
-            if instruction.name == "MPP":
-                # MPP produces one measurement per Pauli product.
-                # Products are separated by spaces; within a product, Paulis are joined by '*' (combiners).
-                # num_measurements = num_non_combiner_targets - num_combiners
-                num_combiners = sum(1 for t in targets if t.is_combiner)
-                num_meas = len(targets) - 2 * num_combiners
-            elif instruction.name in ("MXX", "MYY", "MZZ"):
-                # Pair measurements: targets are listed in pairs and each pair
-                # produces a single measurement record.
-                num_meas = len(targets) // 2
-            else:
-                num_meas = len(targets)
+        if stim.gate_data(instruction.name).produces_measurements:
+            # Ask stim how many records this exact instruction appended,
+            # so we don't have to track the per-gate counting rules ourselves.
+            probe = stim.Circuit()
+            probe.append(instruction)
+            num_meas = probe.num_measurements
             for idx in obs:
                 # update measurement rec indices for the OBSERVABLE_INCLUDE instructions
                 obs[idx] = [t - num_meas for t in obs[idx]]

--- a/test/unit/noise/test_dem.py
+++ b/test/unit/noise/test_dem.py
@@ -217,6 +217,58 @@ def test_get_detector_error_model_with_mpad():
     assert get_detector_error_model(c).approx_equals(expected, atol=1e-12)
 
 
+def test_get_detector_error_model_with_mrz():
+    """MRZ appends one record per target; OBSERVABLE_INCLUDE rec indices must shift."""
+    c = stim.Circuit("""
+        R 0 1
+        X_ERROR(0.1) 0
+        M 0
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        MRZ 1
+        DETECTOR rec[-1]
+        """)
+    expected = c.detector_error_model(allow_gauge_detectors=True)
+    assert get_detector_error_model(c).approx_equals(expected, atol=1e-12)
+
+
+def test_get_detector_error_model_with_heralded_erase():
+    """HERALDED_ERASE appends one record per target; rec indices must shift."""
+    c = stim.Circuit("""
+        R 0 1 2
+        X_ERROR(0.1) 0
+        M 0
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        HERALDED_ERASE(0.05) 1 2
+        DETECTOR rec[-1]
+        DETECTOR rec[-2]
+        """)
+    expected = c.detector_error_model(
+        allow_gauge_detectors=True, approximate_disjoint_errors=True
+    )
+    assert get_detector_error_model(c, approximate_disjoint_errors=True).approx_equals(
+        expected, atol=1e-12
+    )
+
+
+def test_get_detector_error_model_with_heralded_pauli_channel_1():
+    """HERALDED_PAULI_CHANNEL_1 appends one record per target; rec indices must shift."""
+    c = stim.Circuit("""
+        R 0 1 2
+        X_ERROR(0.1) 0
+        M 0
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        HERALDED_PAULI_CHANNEL_1(0.01, 0.02, 0.03, 0.04) 1 2
+        DETECTOR rec[-1]
+        DETECTOR rec[-2]
+        """)
+    expected = c.detector_error_model(
+        allow_gauge_detectors=True, approximate_disjoint_errors=True
+    )
+    assert get_detector_error_model(c, approximate_disjoint_errors=True).approx_equals(
+        expected, atol=1e-12
+    )
+
+
 def test_get_detector_error_model_mpp_measurement_counting():
     """Test correct measurement counting for MPP vs regular M measurements.
 

--- a/test/unit/noise/test_dem.py
+++ b/test/unit/noise/test_dem.py
@@ -171,6 +171,52 @@ def test_get_detector_error_model_with_multiple_mpp_instructions():
     assert dem.num_observables == 1
 
 
+@pytest.mark.parametrize("pair_name", ["MXX", "MYY", "MZZ"])
+def test_get_detector_error_model_with_pair_measurement(pair_name):
+    """Pair measurements MXX/MYY/MZZ add 1 record per qubit pair; the rec
+    indices of preceding OBSERVABLE_INCLUDE instructions must shift accordingly.
+    """
+    c = stim.Circuit(f"""
+        R 0 1
+        X_ERROR(0.1) 0
+        M 0
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        {pair_name} 0 1
+        DETECTOR rec[-1]
+        """)
+    expected = c.detector_error_model(allow_gauge_detectors=True)
+    assert get_detector_error_model(c).approx_equals(expected, atol=1e-12)
+
+
+def test_get_detector_error_model_with_pair_measurement_multi():
+    """Multiple pairs in a single MXX instruction add multiple records."""
+    c = stim.Circuit("""
+        R 0 1 2 3
+        X_ERROR(0.1) 0
+        M 0
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        MXX 0 1 2 3
+        DETECTOR rec[-1]
+        DETECTOR rec[-2]
+        """)
+    expected = c.detector_error_model(allow_gauge_detectors=True)
+    assert get_detector_error_model(c).approx_equals(expected, atol=1e-12)
+
+
+def test_get_detector_error_model_with_mpad():
+    """MPAD writes one record per target; OBSERVABLE_INCLUDE rec indices must shift."""
+    c = stim.Circuit("""
+        R 0
+        X_ERROR(0.1) 0
+        M 0
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        MPAD 0
+        DETECTOR rec[-1]
+        """)
+    expected = c.detector_error_model(allow_gauge_detectors=True)
+    assert get_detector_error_model(c).approx_equals(expected, atol=1e-12)
+
+
 def test_get_detector_error_model_mpp_measurement_counting():
     """Test correct measurement counting for MPP vs regular M measurements.
 


### PR DESCRIPTION
## Summary
- `get_detector_error_model` was missing `MXX`/`MYY`/`MZZ`/`MPAD` from its
  measurement-name list, so `OBSERVABLE_INCLUDE` rec[] indices were not shifted
  when those instructions added measurements. The DEM silently disagreed with
  the sampler; for `MPAD` it even promoted probabilistic logical observables
  to deterministic ones.
- Pair measurements (`MXX`/`MYY`/`MZZ`) get `num_meas = len(targets) // 2`
  (one record per qubit pair); `MPAD` falls through to the default
  `len(targets)`.
- Reorganized the list and removed the duplicate `"MRX"` entry.
