### PR TITLE
Fix matmul_gf2 uint8 saturation corrupting parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MR`, `MRX`, and `MRY` no longer double-count their measurement flip probability as both a pre-measurement Pauli error and a measurement-result flip.
 - Out-of-order `OBSERVABLE_INCLUDE` indices now produce the correct sampler column order and output shape. Missing indices below the maximum mentioned id appear as deterministic-zero columns, and columns are emitted in sorted logical-index order.
 - Empty `DETECTOR` and `OBSERVABLE_INCLUDE` annotations (without targets) no longer crash the parser; they now produce zero detector/observable bits, matching Stim semantics.
+- `matmul_gf2` no longer silently corrupts parity for inner products with more than 255 set bits. The float32→uint8 cast in JAX saturates at 255, which previously made `% 2` always return 1 once a row-sum reached 256. The modulo is now applied on float32 before the uint8 cast.
 
 
 ### Added

--- a/src/tsim/utils/linalg.py
+++ b/src/tsim/utils/linalg.py
@@ -95,6 +95,8 @@ def matmul_gf2(a: Array, b: Array) -> Array:
     G, T, _ = a.shape
     if G * T == 0:
         return jnp.zeros((b.shape[0], G, T), dtype=jnp.uint8)
-    return (b.astype(jnp.float32) @ a.astype(jnp.float32).reshape(G * T, -1).T).reshape(
-        -1, G, T
-    ).astype(jnp.uint8) % 2
+    # NOTE: ``% 2`` must run on float32 — JAX's float→uint8 cast saturates at
+    # 255 (it does not wrap mod 256), which would corrupt parity for inner
+    # products with more than 255 set bits.
+    sum_f32 = b.astype(jnp.float32) @ a.astype(jnp.float32).reshape(G * T, -1).T
+    return (sum_f32.reshape(-1, G, T) % 2).astype(jnp.uint8)

--- a/test/unit/utils/test_linalg.py
+++ b/test/unit/utils/test_linalg.py
@@ -1,8 +1,9 @@
+import jax.numpy as jnp
 import numpy as np
 import pytest
 from galois import GF2
 
-from tsim.utils.linalg import find_basis
+from tsim.utils.linalg import find_basis, matmul_gf2
 
 
 def verify_basis_decomposition(vectors: list[list[int]] | np.ndarray) -> None:
@@ -85,3 +86,37 @@ def test_low_rank_random():
 
     vectors = (mixing @ basis) % 2
     verify_basis_decomposition(vectors)
+
+
+def test_matmul_gf2_matches_numpy_reference():
+    np.random.seed(0)
+    G, T, P, B = 3, 4, 17, 5
+    a_np = np.random.randint(0, 2, size=(G, T, P), dtype=np.uint8)
+    b_np = np.random.randint(0, 2, size=(B, P), dtype=np.uint8)
+
+    expected = (b_np.astype(np.int64) @ a_np.astype(np.int64).reshape(G * T, P).T) % 2
+    expected = expected.reshape(B, G, T).astype(np.uint8)
+
+    result = np.array(matmul_gf2(jnp.asarray(a_np), jnp.asarray(b_np)))
+    assert np.array_equal(result, expected)
+
+
+@pytest.mark.parametrize("p", [256, 300, 1024])
+def test_matmul_gf2_no_uint8_saturation(p):
+    """Regression: ``% 2`` must run on float32 before casting to uint8.
+
+    JAX's float→uint8 cast saturates at 255 instead of wrapping mod 256, so
+    casting before ``% 2`` silently corrupted parity once the inner-product
+    summed more than 255 ones.
+    """
+    a = jnp.ones((1, 1, p), dtype=jnp.uint8)
+    b = jnp.ones((1, p), dtype=jnp.uint8)
+    result = np.array(matmul_gf2(a, b))
+    assert result.flatten()[0] == p % 2
+
+
+def test_matmul_gf2_empty_terms():
+    a = jnp.zeros((0, 0, 4), dtype=jnp.uint8)
+    b = jnp.zeros((2, 4), dtype=jnp.uint8)
+    result = matmul_gf2(a, b)
+    assert result.shape == (2, 0, 0)


### PR DESCRIPTION
## Summary
- `matmul_gf2` cast the float32 row-sum to `uint8` before applying `% 2`. JAX's float→uint8 conversion saturates above 255 (it does not wrap mod 256), so any GF(2) inner product with more than 255 set bits silently returned 1 regardless of the true parity.
- The function is on the compiled-sampler hot path (`compile/terms.py`), so this corrupted probabilities for circuits with wide XOR fan-ins (more than 255 parameters in a single XOR term).
- Fix: apply `% 2` on the float32 result before casting to `uint8`. `% 2` on float32 is exact for sums up to `2**24`.