### PR TITLE
Fix sampler short result with reference + small batch_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Out-of-order `OBSERVABLE_INCLUDE` indices now produce the correct sampler column order and output shape. Missing indices below the maximum mentioned id appear as deterministic-zero columns, and columns are emitted in sorted logical-index order.
 - Empty `DETECTOR` and `OBSERVABLE_INCLUDE` annotations (without targets) no longer crash the parser; they now produce zero detector/observable bits, matching Stim semantics.
 - `matmul_gf2` no longer silently corrupts parity for inner products with more than 255 set bits. The float32→uint8 cast in JAX saturates at 255, which previously made `% 2` always return 1 once a row-sum reached 256. The modulo is now applied on float32 before the uint8 cast.
-- `CompiledDetectorSampler.sample` with `use_detector_reference_sample=True` or `use_observable_reference_sample=True` no longer returns fewer rows than `shots` when called with an explicit `batch_size` that exactly divides `shots`. The internal batch-size bump that reserves a row for the reference sample previously also shrank the loop count, dropping entire batches when the original `batch_size` was small.
+- `CompiledDetectorSampler.sample` with `use_detector_reference_sample=True` or `use_observable_reference_sample=True` no longer returns fewer rows than `shots` when called with an explicit `batch_size` that exactly divides `shots`.
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Out-of-order `OBSERVABLE_INCLUDE` indices now produce the correct sampler column order and output shape. Missing indices below the maximum mentioned id appear as deterministic-zero columns, and columns are emitted in sorted logical-index order.
 - Empty `DETECTOR` and `OBSERVABLE_INCLUDE` annotations (without targets) no longer crash the parser; they now produce zero detector/observable bits, matching Stim semantics.
 - `matmul_gf2` no longer silently corrupts parity for inner products with more than 255 set bits. The float32→uint8 cast in JAX saturates at 255, which previously made `% 2` always return 1 once a row-sum reached 256. The modulo is now applied on float32 before the uint8 cast.
+- `CompiledDetectorSampler.sample` with `use_detector_reference_sample=True` or `use_observable_reference_sample=True` no longer returns fewer rows than `shots` when called with an explicit `batch_size` that exactly divides `shots`. The internal batch-size bump that reserves a row for the reference sample previously also shrank the loop count, dropping entire batches when the original `batch_size` was small.
 
 
 ### Added

--- a/src/tsim/sampler.py
+++ b/src/tsim/sampler.py
@@ -275,17 +275,18 @@ class _CompiledSamplerBase:
             max_batch_size = self._estimate_batch_size()
             num_batches = max(1, ceil(shots / max_batch_size))
             batch_size = ceil(shots / num_batches)
-
-        if compute_reference:
+        else:
             num_batches = ceil(shots / batch_size)
-            has_leeway = batch_size * num_batches > shots
-            if not has_leeway:
-                batch_size += 1
+
+        if compute_reference and batch_size * num_batches == shots:
+            # Bump batch_size so the first batch's reference sample fits
+            # within existing batches (keeps shapes uniform for JIT).
+            batch_size += 1
 
         batches: list[jax.Array] = []
         reference: np.ndarray | None = None
 
-        for _ in range(ceil(shots / batch_size)):
+        for _ in range(num_batches):
             f_params_np = self._channel_sampler.sample(batch_size)
 
             if compute_reference and reference is None:

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -220,6 +220,10 @@ def make_sampler():
         (100, None, 50, True, 51, 2),
         # Explicit batch_size, has leeway → stays
         (100, None, 51, True, 51, 2),
+        # Small explicit batch_size where bump shrinks ceil(shots/batch_size):
+        # num_batches must reflect the pre-bump count or samples are short.
+        (2, None, 1, True, 2, 2),
+        (12, None, 3, True, 4, 4),
     ],
     ids=[
         "leeway-no-bump",
@@ -228,6 +232,8 @@ def make_sampler():
         "no-reference",
         "explicit-no-leeway",
         "explicit-leeway",
+        "explicit-small-no-leeway-bump",
+        "explicit-small-no-leeway-bump-multi",
     ],
 )
 def test_batch_size_with_reference(


### PR DESCRIPTION
## Summary
- Fix `CompiledDetectorSampler.sample` returning fewer rows than `shots` when called with `use_detector_reference_sample=True` (or `use_observable_reference_sample=True`) and an explicit `batch_size` that exactly divides `shots`.
- In `_sample_batches`, the existing logic bumps `batch_size += 1` to fit the first batch's reference row without adding an extra batch. But the loop was driven by `ceil(shots / batch_size)` recomputed *after* the bump, which shrank the loop count when the original `batch_size` was small (1, 2, 3, …) and silently dropped entire batches.
- Stash `num_batches` before the bump and use it as the loop count, so the bump only widens batches.