### PR TITLE
Validate probabilities in noise channel constructors

### DIFF
--- a/src/tsim/noise/channels.py
+++ b/src/tsim/noise/channels.py
@@ -33,11 +33,28 @@ class Channel:
         return int(np.log2(len(self.probs)))
 
 
+_PROB_SUM_TOL = 1e-9
+
+
+def _validate_probabilities(*probs: float) -> None:
+    """Validate that each probability is in ``[0, 1]`` and they sum to at most 1.
+
+    Raises:
+        ValueError: If any probability is outside ``[0, 1]`` or the sum exceeds 1.
+
+    """
+    if any(p < 0.0 or p > 1.0 for p in probs):
+        raise ValueError("probabilities must lie in [0, 1]")
+    if sum(probs) > 1.0 + _PROB_SUM_TOL:
+        raise ValueError("probabilities must sum to at most 1")
+
+
 def error_probs(p: float) -> np.ndarray:
     """Single-bit error channel.
 
     Returns ``[P(bit0=0), P(bit0=1)]``.
     """
+    _validate_probabilities(p)
     return np.array([1 - p, p], dtype=np.float64)
 
 
@@ -58,6 +75,7 @@ def heralded_pauli_channel_1_probs(
     - index 5 (0b101): herald + X
     - index 7 (0b111): herald + Y, represented as X+Z
     """
+    _validate_probabilities(pi, px, py, pz)
     probs = np.zeros(8, dtype=np.float64)
     probs[0] = 1 - pi - px - py - pz
     probs[1] = pi
@@ -80,6 +98,7 @@ def pauli_channel_1_probs(px: float, py: float, pz: float) -> np.ndarray:
     - index 2 (0b10): X
     - index 3 (0b11): Y
     """
+    _validate_probabilities(px, py, pz)
     return np.array([1 - px - py - pz, pz, px, py], dtype=np.float64)
 
 
@@ -113,6 +132,9 @@ def pauli_channel_2_probs(
     follow Stim's naming convention: ``pix`` is I on ``qubit_i`` and X on
     ``qubit_j``, ``pzi`` is Z on ``qubit_i`` and I on ``qubit_j``, etc.
     """
+    _validate_probabilities(
+        pix, piy, piz, pxi, pxx, pxy, pxz, pyi, pyx, pyy, pyz, pzi, pzx, pzy, pzz
+    )
     remainder = (
         1
         - pix
@@ -592,6 +614,9 @@ class ChannelSampler:
             probs = ch.probs.astype(np.float64)
             p_fire = 1.0 - float(probs[0])
             n_outcomes = len(probs)
+
+            if p_fire < -_PROB_SUM_TOL:
+                raise ValueError("channel has invalid probabilities")
 
             if p_fire <= 1e-15 or n_outcomes <= 1:
                 continue

--- a/src/tsim/noise/channels.py
+++ b/src/tsim/noise/channels.py
@@ -27,26 +27,20 @@ class Channel:
     probs: np.ndarray
     unique_col_ids: tuple[int, ...]
 
+    def __post_init__(self) -> None:
+        """Validate channel probabilities."""
+        if np.any(self.probs < 0.0) or np.any(self.probs > 1.0):
+            raise ValueError(f"Probabilities must lie in [0, 1], but got: {self.probs}")
+        if not np.isclose(np.sum(self.probs), 1.0):
+            raise ValueError(
+                f"Probabilities must sum to 1, but got: {self.probs} "
+                f"(sum {np.sum(self.probs)})"
+            )
+
     @property
     def num_bits(self) -> int:
         """Number of bits in the channel (k where probs has shape 2^k)."""
         return int(np.log2(len(self.probs)))
-
-
-_PROB_SUM_TOL = 1e-9
-
-
-def _validate_probabilities(*probs: float) -> None:
-    """Validate that each probability is in ``[0, 1]`` and they sum to at most 1.
-
-    Raises:
-        ValueError: If any probability is outside ``[0, 1]`` or the sum exceeds 1.
-
-    """
-    if any(p < 0.0 or p > 1.0 for p in probs):
-        raise ValueError("probabilities must lie in [0, 1]")
-    if sum(probs) > 1.0 + _PROB_SUM_TOL:
-        raise ValueError("probabilities must sum to at most 1")
 
 
 def error_probs(p: float) -> np.ndarray:
@@ -54,7 +48,6 @@ def error_probs(p: float) -> np.ndarray:
 
     Returns ``[P(bit0=0), P(bit0=1)]``.
     """
-    _validate_probabilities(p)
     return np.array([1 - p, p], dtype=np.float64)
 
 
@@ -75,7 +68,6 @@ def heralded_pauli_channel_1_probs(
     - index 5 (0b101): herald + X
     - index 7 (0b111): herald + Y, represented as X+Z
     """
-    _validate_probabilities(pi, px, py, pz)
     probs = np.zeros(8, dtype=np.float64)
     probs[0] = 1 - pi - px - py - pz
     probs[1] = pi
@@ -98,7 +90,6 @@ def pauli_channel_1_probs(px: float, py: float, pz: float) -> np.ndarray:
     - index 2 (0b10): X
     - index 3 (0b11): Y
     """
-    _validate_probabilities(px, py, pz)
     return np.array([1 - px - py - pz, pz, px, py], dtype=np.float64)
 
 
@@ -132,9 +123,6 @@ def pauli_channel_2_probs(
     follow Stim's naming convention: ``pix`` is I on ``qubit_i`` and X on
     ``qubit_j``, ``pzi`` is Z on ``qubit_i`` and I on ``qubit_j``, etc.
     """
-    _validate_probabilities(
-        pix, piy, piz, pxi, pxx, pxy, pxz, pyi, pyx, pyy, pyz, pzi, pzx, pzy, pzz
-    )
     remainder = (
         1
         - pix
@@ -614,9 +602,6 @@ class ChannelSampler:
             probs = ch.probs.astype(np.float64)
             p_fire = 1.0 - float(probs[0])
             n_outcomes = len(probs)
-
-            if p_fire < -_PROB_SUM_TOL:
-                raise ValueError("channel has invalid probabilities")
 
             if p_fire <= 1e-15 or n_outcomes <= 1:
                 continue

--- a/src/tsim/noise/channels.py
+++ b/src/tsim/noise/channels.py
@@ -29,7 +29,8 @@ class Channel:
 
     def __post_init__(self) -> None:
         """Validate channel probabilities."""
-        if np.any(self.probs < 0.0) or np.any(self.probs > 1.0):
+        tol = 1e-12
+        if np.any(self.probs < -tol) or np.any(self.probs > 1.0 + tol):
             raise ValueError(f"Probabilities must lie in [0, 1], but got: {self.probs}")
         if not np.isclose(np.sum(self.probs), 1.0):
             raise ValueError(

--- a/test/unit/noise/test_channels.py
+++ b/test/unit/noise/test_channels.py
@@ -162,34 +162,35 @@ class TestCorrelatedErrorProbs:
         assert_allclose(probs[4], 0.0)  # index 4 (0b100): third error
 
 
-class TestProbabilityValidation:
-    """The probability helpers reject invalid inputs instead of producing
-    malformed distributions that get silently dropped downstream."""
+class TestChannelValidation:
+    """Channel.__post_init__ rejects malformed probability distributions so
+    they cannot reach the sampler and get silently dropped."""
 
-    def test_error_probs_rejects_out_of_range(self):
+    def test_rejects_negative_entry(self):
         with pytest.raises(ValueError):
-            error_probs(1.5)
-        with pytest.raises(ValueError):
-            error_probs(-0.1)
+            Channel(probs=np.array([1.2, -0.2]), unique_col_ids=(0,))
 
-    def test_pauli_channel_1_rejects_sum_above_one(self):
+    def test_rejects_entry_above_one(self):
         with pytest.raises(ValueError):
-            pauli_channel_1_probs(0.6, 0.6, 0.6)
+            Channel(probs=np.array([-0.5, 1.5]), unique_col_ids=(0,))
 
-    def test_pauli_channel_1_rejects_negative(self):
+    def test_rejects_sum_below_one(self):
         with pytest.raises(ValueError):
-            pauli_channel_1_probs(-0.1, 0.1, 0.1)
+            Channel(probs=np.array([0.5, 0.4]), unique_col_ids=(0,))
 
-    def test_pauli_channel_2_rejects_sum_above_one(self):
+    def test_rejects_sum_above_one(self):
         with pytest.raises(ValueError):
-            pauli_channel_2_probs(*([0.1] * 15))
+            Channel(probs=np.array([0.7, 0.7]), unique_col_ids=(0,))
 
-    def test_heralded_pauli_channel_1_rejects_sum_above_one(self):
+    def test_rejects_helper_with_arguments_summing_above_one(self):
+        # pauli_channel_1_probs(0.6, 0.6, 0.6) returns probs[0] = -0.8.
+        # Wrapping in a Channel surfaces the negative entry as a clear error.
         with pytest.raises(ValueError):
-            heralded_pauli_channel_1_probs(pi=0.5, px=0.3, py=0.3, pz=0.0)
+            Channel(probs=pauli_channel_1_probs(0.6, 0.6, 0.6), unique_col_ids=(0, 1))
 
     def test_channel_sampler_rejects_invalid_channel(self):
-        # Construct a Channel whose probs[0] exceeds 1, bypassing the helpers.
+        # ChannelSampler wraps probs in a Channel, so invalid distributions
+        # get caught at construction time rather than silently dropped.
         bad_probs = np.array([1.2, -0.1, -0.05, -0.05])
         transform = np.array([[1, 0], [0, 1]], dtype=np.uint8)
         with pytest.raises(ValueError):

--- a/test/unit/noise/test_channels.py
+++ b/test/unit/noise/test_channels.py
@@ -162,6 +162,40 @@ class TestCorrelatedErrorProbs:
         assert_allclose(probs[4], 0.0)  # index 4 (0b100): third error
 
 
+class TestProbabilityValidation:
+    """The probability helpers reject invalid inputs instead of producing
+    malformed distributions that get silently dropped downstream."""
+
+    def test_error_probs_rejects_out_of_range(self):
+        with pytest.raises(ValueError):
+            error_probs(1.5)
+        with pytest.raises(ValueError):
+            error_probs(-0.1)
+
+    def test_pauli_channel_1_rejects_sum_above_one(self):
+        with pytest.raises(ValueError):
+            pauli_channel_1_probs(0.6, 0.6, 0.6)
+
+    def test_pauli_channel_1_rejects_negative(self):
+        with pytest.raises(ValueError):
+            pauli_channel_1_probs(-0.1, 0.1, 0.1)
+
+    def test_pauli_channel_2_rejects_sum_above_one(self):
+        with pytest.raises(ValueError):
+            pauli_channel_2_probs(*([0.1] * 15))
+
+    def test_heralded_pauli_channel_1_rejects_sum_above_one(self):
+        with pytest.raises(ValueError):
+            heralded_pauli_channel_1_probs(pi=0.5, px=0.3, py=0.3, pz=0.0)
+
+    def test_channel_sampler_rejects_invalid_channel(self):
+        # Construct a Channel whose probs[0] exceeds 1, bypassing the helpers.
+        bad_probs = np.array([1.2, -0.1, -0.05, -0.05])
+        transform = np.array([[1, 0], [0, 1]], dtype=np.uint8)
+        with pytest.raises(ValueError):
+            ChannelSampler([bad_probs], transform, seed=42)
+
+
 def _sample_channels(channels, matrix, n_samples, seed=42):
     """Sample from channels using the ChannelSampler infrastructure."""
     sampler = object.__new__(ChannelSampler)


### PR DESCRIPTION
## Summary

The Pauli channel probability helpers (`error_probs`, `pauli_channel_1_probs`, `pauli_channel_2_probs`, `heralded_pauli_channel_1_probs`) accepted invalid inputs and produced malformed distributions: `probs[0]` could come out negative when individual entries were outside `[0, 1]` or their sum exceeded 1. `ChannelSampler._precompute_sparse` then silently dropped those channels because `p_fire = 1 - probs[0] > 1` doesn't trigger its `p_fire <= 1e-15` early-return — sampling proceeded as if the channel did nothing.

In the normal stim-driven pipeline this is unreachable (stim rejects bad probabilities at parse time), but it bites anyone constructing a `Channel` directly.

- Added `_validate_probabilities` to check each input is in `[0, 1]` and the sum is ≤ 1.
- Wired it into all four Pauli helpers.
- `ChannelSampler._precompute_sparse` now raises `ValueError` when `p_fire < 0` instead of silently skipping.