### PR TITLE
Fix visualization of correlated error instructions in pyzx renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Empty `DETECTOR` and `OBSERVABLE_INCLUDE` annotations (without targets) no longer crash the parser; they now produce zero detector/observable bits, matching Stim semantics.
 - `matmul_gf2` no longer silently corrupts parity for inner products with more than 255 set bits. The float32→uint8 cast in JAX saturates at 255, which previously made `% 2` always return 1 once a row-sum reached 256. The modulo is now applied on float32 before the uint8 cast.
 - `CompiledDetectorSampler.sample` with `use_detector_reference_sample=True` or `use_observable_reference_sample=True` no longer returns fewer rows than `shots` when called with an explicit `batch_size` that exactly divides `shots`.
+- Incorrect visualization of `CORRELATED_ERROR` and `ELSE_CORRELATED_ERROR` instructions in the `pyzx` diagram renderer. Previously, error vertices were rendered as classical spiders instead of bold quantum spiders.
 
 
 ### Added

--- a/src/tsim/core/instructions.py
+++ b/src/tsim/core/instructions.py
@@ -802,9 +802,9 @@ def correlated_error(
     """Add a correlated error term affecting multiple qubits with given Pauli types."""
     for qubit, type_ in zip(qubits, types, strict=True):
         if type_ == "X" or type_ == "Y":
-            _error(b, qubit, VertexType.X, f"c{b.num_correlated_error_bits}")
+            _error(b, qubit, b.vertex_type.X, f"c{b.num_correlated_error_bits}")
         if type_ == "Z" or type_ == "Y":
-            _error(b, qubit, VertexType.Z, f"c{b.num_correlated_error_bits}")
+            _error(b, qubit, b.vertex_type.Z, f"c{b.num_correlated_error_bits}")
 
     b.correlated_error_probs.append(p)
     b.num_correlated_error_bits += 1


### PR DESCRIPTION
- Corrected the rendering of `CORRELATED_ERROR` and `ELSE_CORRELATED_ERROR` instructions in the pyzx diagram renderer. Previously, error vertices were incorrectly displayed as classical spiders instead of bold quantum spiders, aligning the visualization with expected behavior.

Before
```python
import tsim
c = tsim.Circuit("""R 0
E(0.1) X0 Z1
ELSE_CORRELATED_ERROR(0.2) Y0
M 0""")
c.diagram("pyzx")
```
lead to
<img width="209" height="117" alt="image" src="https://github.com/user-attachments/assets/69fabcf9-d752-4f3a-a788-6d411b472682" />


With this fix,
<img width="257" height="94" alt="image" src="https://github.com/user-attachments/assets/4a80484a-2111-4a52-819b-af5efdfec68a" />
