### PR TITLE
Match Stim semantics for detector sampler observable flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `CompiledDetectorSampler.sample` now raises `ValueError` when `separate_observables=True` is combined with `prepend_observables=True` or `append_observables=True` (matching Stim), and also when both `prepend_observables=True` and `append_observables=True` are set. Previously these combinations silently dropped observable columns.
 - `MR`, `MRX`, and `MRY` no longer double-count their measurement flip probability as both a pre-measurement Pauli error and a measurement-result flip.
 - Out-of-order `OBSERVABLE_INCLUDE` indices now produce the correct sampler column order and output shape. Missing indices below the maximum mentioned id appear as deterministic-zero columns, and columns are emitted in sorted logical-index order.
 - Empty `DETECTOR` and `OBSERVABLE_INCLUDE` annotations (without targets) no longer crash the parser; they now produce zero detector/observable bits, matching Stim semantics.

--- a/src/tsim/sampler.py
+++ b/src/tsim/sampler.py
@@ -526,11 +526,20 @@ class CompiledDetectorSampler(_CompiledSamplerBase):
         Returns:
             A numpy array or tuple of numpy arrays containing the samples.
 
+        Raises:
+            ValueError: If ``separate_observables`` is combined with
+                ``prepend_observables`` or ``append_observables``, or if both
+                ``prepend_observables`` and ``append_observables`` are set.
+
         """
         if separate_observables and (prepend_observables or append_observables):
             raise ValueError(
                 "Can't specify separate_observables=True with "
                 "append_observables=True or prepend_observables=True"
+            )
+        if prepend_observables and append_observables:
+            raise ValueError(
+                "Can't specify both prepend_observables=True and append_observables=True"
             )
 
         compute_reference = (
@@ -549,25 +558,23 @@ class CompiledDetectorSampler(_CompiledSamplerBase):
         else:
             samples = self._sample_batches(shots, batch_size)
 
+        if append_observables:
+            return _maybe_bit_pack(samples, bit_packed=bit_packed)
+
         num_detectors = self._num_detectors
         det_samples = samples[:, :num_detectors]
         obs_samples = samples[:, num_detectors:]
 
+        if prepend_observables:
+            combined = np.concatenate([obs_samples, det_samples], axis=1)
+            return _maybe_bit_pack(combined, bit_packed=bit_packed)
         if separate_observables:
             return (
                 _maybe_bit_pack(det_samples, bit_packed=bit_packed),
                 _maybe_bit_pack(obs_samples, bit_packed=bit_packed),
             )
 
-        parts: list[np.ndarray] = []
-        if prepend_observables:
-            parts.append(obs_samples)
-        parts.append(det_samples)
-        if append_observables:
-            parts.append(obs_samples)
-
-        combined = parts[0] if len(parts) == 1 else np.concatenate(parts, axis=1)
-        return _maybe_bit_pack(combined, bit_packed=bit_packed)
+        return _maybe_bit_pack(det_samples, bit_packed=bit_packed)
         # TODO: don't compute observables if they are discarded here
 
 

--- a/src/tsim/sampler.py
+++ b/src/tsim/sampler.py
@@ -527,6 +527,12 @@ class CompiledDetectorSampler(_CompiledSamplerBase):
             A numpy array or tuple of numpy arrays containing the samples.
 
         """
+        if separate_observables and (prepend_observables or append_observables):
+            raise ValueError(
+                "Can't specify separate_observables=True with "
+                "append_observables=True or prepend_observables=True"
+            )
+
         compute_reference = (
             use_detector_reference_sample or use_observable_reference_sample
         )
@@ -543,23 +549,25 @@ class CompiledDetectorSampler(_CompiledSamplerBase):
         else:
             samples = self._sample_batches(shots, batch_size)
 
-        if append_observables:
-            return _maybe_bit_pack(samples, bit_packed=bit_packed)
-
         num_detectors = self._num_detectors
         det_samples = samples[:, :num_detectors]
         obs_samples = samples[:, num_detectors:]
 
-        if prepend_observables:
-            combined = np.concatenate([obs_samples, det_samples], axis=1)
-            return _maybe_bit_pack(combined, bit_packed=bit_packed)
         if separate_observables:
             return (
                 _maybe_bit_pack(det_samples, bit_packed=bit_packed),
                 _maybe_bit_pack(obs_samples, bit_packed=bit_packed),
             )
 
-        return _maybe_bit_pack(det_samples, bit_packed=bit_packed)
+        parts: list[np.ndarray] = []
+        if prepend_observables:
+            parts.append(obs_samples)
+        parts.append(det_samples)
+        if append_observables:
+            parts.append(obs_samples)
+
+        combined = parts[0] if len(parts) == 1 else np.concatenate(parts, axis=1)
+        return _maybe_bit_pack(combined, bit_packed=bit_packed)
         # TODO: don't compute observables if they are discarded here
 
 

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -30,6 +30,46 @@ def test_detector_sampler_args():
     assert np.array_equal(o, np.array([[1]]))
 
 
+def test_detector_sampler_prepend_and_append_duplicates_observables():
+    """Matches Stim: setting both prepend and append surrounds detectors with observables."""
+    c = Circuit("""
+        R 0 1 2
+        X 2
+        M 0 1 2
+        DETECTOR rec[-2]
+        DETECTOR rec[-3]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        """)
+    sampler = c.compile_detector_sampler()
+    d = sampler.sample(1, prepend_observables=True, append_observables=True)
+    assert np.array_equal(d, np.array([[1, 0, 0, 1]]))
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"separate_observables": True, "append_observables": True},
+        {"separate_observables": True, "prepend_observables": True},
+        {
+            "separate_observables": True,
+            "append_observables": True,
+            "prepend_observables": True,
+        },
+    ],
+)
+def test_detector_sampler_separate_with_prepend_or_append_raises(kwargs):
+    """Matches Stim: separate_observables cannot be combined with prepend/append."""
+    c = Circuit("""
+        R 0
+        M 0
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        """)
+    sampler = c.compile_detector_sampler()
+    with pytest.raises(ValueError, match="separate_observables"):
+        sampler.sample(1, **kwargs)
+
+
 def test_measurement_sampler_zero_shots():
     """Measurement sampler with shots=0 returns an empty (0, num_measurements) array."""
     c = Circuit("H 0\nM 0")

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -30,35 +30,33 @@ def test_detector_sampler_args():
     assert np.array_equal(o, np.array([[1]]))
 
 
-def test_detector_sampler_prepend_and_append_duplicates_observables():
-    """Matches Stim: setting both prepend and append surrounds detectors with observables."""
-    c = Circuit("""
-        R 0 1 2
-        X 2
-        M 0 1 2
-        DETECTOR rec[-2]
-        DETECTOR rec[-3]
-        OBSERVABLE_INCLUDE(0) rec[-1]
-        """)
-    sampler = c.compile_detector_sampler()
-    d = sampler.sample(1, prepend_observables=True, append_observables=True)
-    assert np.array_equal(d, np.array([[1, 0, 0, 1]]))
-
-
 @pytest.mark.parametrize(
-    "kwargs",
+    ("kwargs", "match"),
     [
-        {"separate_observables": True, "append_observables": True},
-        {"separate_observables": True, "prepend_observables": True},
-        {
-            "separate_observables": True,
-            "append_observables": True,
-            "prepend_observables": True,
-        },
+        (
+            {"separate_observables": True, "append_observables": True},
+            "separate_observables",
+        ),
+        (
+            {"separate_observables": True, "prepend_observables": True},
+            "separate_observables",
+        ),
+        (
+            {
+                "separate_observables": True,
+                "append_observables": True,
+                "prepend_observables": True,
+            },
+            "separate_observables",
+        ),
+        (
+            {"prepend_observables": True, "append_observables": True},
+            "prepend_observables",
+        ),
     ],
 )
-def test_detector_sampler_separate_with_prepend_or_append_raises(kwargs):
-    """Matches Stim: separate_observables cannot be combined with prepend/append."""
+def test_detector_sampler_invalid_observable_flag_combos_raise(kwargs, match):
+    """Conflicting observable placement flags must raise rather than silently drop columns."""
     c = Circuit("""
         R 0
         M 0
@@ -66,7 +64,7 @@ def test_detector_sampler_separate_with_prepend_or_append_raises(kwargs):
         OBSERVABLE_INCLUDE(0) rec[-1]
         """)
     sampler = c.compile_detector_sampler()
-    with pytest.raises(ValueError, match="separate_observables"):
+    with pytest.raises(ValueError, match=match):
         sampler.sample(1, **kwargs)
 
 


### PR DESCRIPTION
## Summary

`CompiledDetectorSampler.sample` diverged from Stim on three flag combinations:

- `prepend_observables=True` + `append_observables=True`: tsim silently picked one and dropped the other column. Stim duplicates observables, returning `[obs, det, obs]`.
- `separate_observables=True` combined with `append_observables=True` or `prepend_observables=True`: tsim ignored the conflict and returned a flat detector array. Stim raises `ValueError`.

This change matches Stim's behavior in both cases.