### PR TITLE
Accept scientific notation in stim_to_shorthand round-trip

### DIFF
--- a/src/tsim/utils/program_text.py
+++ b/src/tsim/utils/program_text.py
@@ -85,7 +85,7 @@ def stim_to_shorthand(text: str) -> str:
         return f"U3({theta}, {phi}, {lam})"
 
     text = re.sub(
-        r"\bI\[U3\(theta=([-+]?[\d.]+)\*pi, phi=([-+]?[\d.]+)\*pi, lambda=([-+]?[\d.]+)\*pi\)\]",
+        rf"\bI\[U3\(theta=({_FLOAT_RE})\*pi, phi=({_FLOAT_RE})\*pi, lambda=({_FLOAT_RE})\*pi\)\]",
         replace_u3,
         text,
     )
@@ -97,7 +97,7 @@ def stim_to_shorthand(text: str) -> str:
         return f"R_{axis}({angle})"
 
     text = re.sub(
-        r"\bI\[R_([XYZ])\(theta=([-+]?[\d.]+)\*pi\)\]",
+        rf"\bI\[R_([XYZ])\(theta=({_FLOAT_RE})\*pi\)\]",
         replace_rotation,
         text,
     )

--- a/test/unit/utils/test_program_text.py
+++ b/test/unit/utils/test_program_text.py
@@ -83,6 +83,24 @@ def test_circuit_scientific_notation():
     assert len(c) == 1
 
 
+def test_stim_to_shorthand_rotation_scientific_notation():
+    text = "I[R_Z(theta=1e-07*pi)] 0\nI[R_X(theta=-2.5e+02*pi)] 1"
+    expected = "R_Z(1e-07) 0\nR_X(-2.5e+02) 1"
+    assert stim_to_shorthand(text) == expected
+
+
+def test_stim_to_shorthand_u3_scientific_notation():
+    text = "I[U3(theta=1e-07*pi, phi=2e-07*pi, lambda=3e-07*pi)] 0"
+    expected = "U3(1e-07, 2e-07, 3e-07) 0"
+    assert stim_to_shorthand(text) == expected
+
+
+def test_circuit_str_scientific_notation_roundtrip():
+    for program in ["R_Z(1e-7) 0", "U3(1e-7, 2e-7, 3e-7) 0"]:
+        rendered = str(Circuit(program))
+        assert "I[" not in rendered, rendered
+
+
 @pytest.mark.parametrize(
     "text, snippet",
     [


### PR DESCRIPTION
## Summary

`shorthand_to_stim` already accepts scientific notation (`R_Z(1e-7) 0`), but `stim_to_shorthand` only matched decimal-looking tokens. As a result, `str(Circuit("R_Z(1e-7) 0"))` returned the internal `I[R_Z(theta=1e-07*pi)] 0` annotation rather than the public shorthand.

The U3 and rotation patterns in `stim_to_shorthand` now reuse the shared `_FLOAT_RE` pattern, so exponent notation round-trips back to shorthand.