### PR TITLE
Reject sweep bit targets in stim circuit parser

### DIFF
--- a/src/tsim/core/parse.py
+++ b/src/tsim/core/parse.py
@@ -189,7 +189,7 @@ def parse_stim_circuit(
         if any(t.is_sweep_bit_target for t in instruction.targets_copy()):
             raise NotImplementedError(
                 f"Sweep bit targets (e.g. sweep[N]) are not supported "
-                f"in instruction {name!r}"
+                f"in instruction {str(instruction)!r}"
             )
 
         if name == "S" and instruction.tag == "T":

--- a/src/tsim/core/parse.py
+++ b/src/tsim/core/parse.py
@@ -186,6 +186,12 @@ def parse_stim_circuit(
             # TODO: handle visualization annotations in ZX diagrams
             continue
 
+        if any(t.is_sweep_bit_target for t in instruction.targets_copy()):
+            raise NotImplementedError(
+                f"Sweep bit targets (e.g. sweep[N]) are not supported "
+                f"in instruction {name!r}"
+            )
+
         if name == "S" and instruction.tag == "T":
             name = "T"
         elif name == "S_DAG" and instruction.tag == "T":

--- a/test/unit/core/test_parse.py
+++ b/test/unit/core/test_parse.py
@@ -1002,3 +1002,20 @@ class TestParseParametricTag:
             match=r"Could not parse instruction 'I\[U3\(theta=0\.5\*pi\)\] 0 1'",
         ):
             parse_parametric_tag(instr)
+
+
+class TestSweepTargets:
+    """Sweep targets are not supported and must raise rather than be silently lowered as qubit targets."""
+
+    @pytest.mark.parametrize(
+        "program",
+        [
+            "CX sweep[0] 1",
+            "CZ 0 sweep[1]",
+            "CY sweep[2] 0",
+        ],
+    )
+    def test_sweep_target_raises(self, program):
+        circuit = stim.Circuit(program)
+        with pytest.raises(NotImplementedError, match="Sweep bit targets"):
+            parse_stim_circuit(circuit)


### PR DESCRIPTION
## Summary

`parse_stim_circuit` lowered every target through `t.value` and only branched on `is_measurement_record_target`, so `CX sweep[0] 1` was silently parsed as an unconditional `CX 0 1` — producing a wrong matrix without any warning.

Sweep parameters are not supported by tsim. The parser now detects `is_sweep_bit_target` on any instruction and raises `NotImplementedError` so unsupported circuits fail loud at parse time.