### PR TITLE
Validate sampler shots, batch_size and state shape

### DIFF
--- a/src/tsim/sampler.py
+++ b/src/tsim/sampler.py
@@ -265,6 +265,11 @@ class _CompiledSamplerBase:
             Samples array, or (samples, reference) tuple when compute_reference=True.
 
         """
+        if shots < 0:
+            raise ValueError(f"shots must be non-negative, got {shots}")
+        if batch_size is not None and batch_size < 1:
+            raise ValueError(f"batch_size must be at least 1, got {batch_size}")
+
         if shots == 0:
             empty = np.empty((0, self._program.num_outputs), dtype=np.bool_)
             if compute_reference:
@@ -609,6 +614,13 @@ class CompiledStateProbs(_CompiledSamplerBase):
             Array of probabilities P(state | error_sample) for each error sample.
 
         """
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be at least 1, got {batch_size}")
+        expected_outputs = self._program.num_outputs
+        if state.shape != (expected_outputs,):
+            raise ValueError(
+                f"state must have shape ({expected_outputs},), got {state.shape}"
+            )
         f_samples = jnp.asarray(self._channel_sampler.sample(batch_size))
         p_norm = jnp.ones(batch_size)
         p_joint = jnp.ones(batch_size)

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -131,6 +131,40 @@ def test_detector_sampler_no_detectors_bit_packed():
     assert result.shape == (5, 0)
 
 
+def test_sampler_negative_shots_raises():
+    sampler = Circuit("H 0\nM 0").compile_sampler(seed=0)
+    with pytest.raises(ValueError, match="shots must be non-negative"):
+        sampler.sample(-1)
+
+
+def test_sampler_zero_batch_size_raises():
+    sampler = Circuit("H 0\nM 0").compile_sampler(seed=0)
+    with pytest.raises(ValueError, match="batch_size must be at least 1"):
+        sampler.sample(1, batch_size=0)
+
+
+def test_sampler_negative_batch_size_raises():
+    sampler = Circuit("H 0\nM 0").compile_sampler(seed=0)
+    with pytest.raises(ValueError, match="batch_size must be at least 1"):
+        sampler.sample(1, batch_size=-3)
+
+
+def test_state_probs_rejects_wrong_state_length():
+    from tsim.sampler import CompiledStateProbs
+
+    sampler = CompiledStateProbs(Circuit("M 0"))
+    with pytest.raises(ValueError, match=r"state must have shape \(1,\)"):
+        sampler.probability_of(np.array([False, True]), batch_size=1)
+
+
+def test_state_probs_rejects_invalid_batch_size():
+    from tsim.sampler import CompiledStateProbs
+
+    sampler = CompiledStateProbs(Circuit("M 0"))
+    with pytest.raises(ValueError, match="batch_size must be at least 1"):
+        sampler.probability_of(np.array([False]), batch_size=0)
+
+
 def test_sampler_repr_no_measurements():
     """repr() on a sampler with no measurements should not error."""
     c = Circuit("H 0")


### PR DESCRIPTION
## Summary

The compiled samplers exposed three input-validation gaps that surfaced as confusing internal errors or silent acceptance of bad input:

- **Negative shots** reached `np.concatenate` of an empty list and raised `"need at least one array to concatenate"`.
- **`batch_size=0`** hit a `ZeroDivisionError` when computing `num_batches`.
- **Wrong state length** in `CompiledStateProbs.probability_of` was silently truncated by integer-array indexing — extra bits were just dropped.

`_sample_batches` now rejects negative shots and non-positive `batch_size`, and `probability_of` now requires the state vector to match `num_outputs` exactly. Each invalid input raises an explicit `ValueError`.