### PR TITLE
Fix observable flag combos, diagram parsing, and graph helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- `CompiledDetectorSampler.sample` now raises `ValueError` when `separate_observables=True` is combined with `prepend_observables=True` or `append_observables=True` (matching Stim), and also when both `prepend_observables=True` and `append_observables=True` are set. Previously these combinations silently dropped observable columns.
 - `MR`, `MRX`, and `MRY` no longer double-count their measurement flip probability as both a pre-measurement Pauli error and a measurement-result flip.
+- Fixed a bug where `M(p)` instructions incorrectly flipped the qubit, not just the measurement record. This would affect circuits where qubits were measured and not immediately reset.
+- Fixed a bug where `MR !q` instructions (with measurement record inversion) produced wrong measurement results.
 - Out-of-order `OBSERVABLE_INCLUDE` indices now produce the correct sampler column order and output shape. Missing indices below the maximum mentioned id appear as deterministic-zero columns, and columns are emitted in sorted logical-index order.
-- Empty `DETECTOR` and `OBSERVABLE_INCLUDE` annotations (without targets) no longer crash the parser; they now produce zero detector/observable bits, matching Stim semantics.
 - `matmul_gf2` no longer silently corrupts parity for inner products with more than 255 set bits. The float32→uint8 cast in JAX saturates at 255, which previously made `% 2` always return 1 once a row-sum reached 256. The modulo is now applied on float32 before the uint8 cast.
+- `CompiledDetectorSampler.sample` now raises `ValueError` when `separate_observables=True` is combined with `prepend_observables=True` or `append_observables=True` (matching Stim). Previously these combinations silently dropped observable columns. The `prepend_observables=True` + `append_observables=True` combination is now supported and returns columns in `[obs, det, obs]` order, matching Stim.
+- `OBSERVABLE_INCLUDE` with Pauli targets (e.g. `OBSERVABLE_INCLUDE(0) X1`) now raises `ValueError` instead of silently producing wrong observable bits or crashing with `IndexError`. tsim only supports measurement-record targets (`rec[-k]`).
+- Empty `DETECTOR` and `OBSERVABLE_INCLUDE` annotations (without targets) no longer crash the parser; they now produce zero detector/observable bits, matching Stim semantics.
 - `CompiledDetectorSampler.sample` with `use_detector_reference_sample=True` or `use_observable_reference_sample=True` no longer returns fewer rows than `shots` when called with an explicit `batch_size` that exactly divides `shots`.
 - Incorrect visualization of `CORRELATED_ERROR` and `ELSE_CORRELATED_ERROR` instructions in the `pyzx` diagram renderer. Previously, error vertices were rendered as classical spiders instead of bold quantum spiders.
-- Fixed a bug where `M(p)` instructions incorrectly flipped the qubit, not just the measurement record.
-- Fixed a bug where `MR !q` instructions produced wrong measurement results.
 
 
 ### Added

--- a/src/tsim/core/graph.py
+++ b/src/tsim/core/graph.py
@@ -70,7 +70,7 @@ def _collect_vertices(
     start: Any,
     visited: set[Any],
 ) -> list[Any]:
-    """Breadth-first search to collect the connected component of ``start``."""
+    """Depth-first search to collect the connected component of ``start``."""
     queue: deque[Any] = deque([start])
     component: list[Any] = []
 
@@ -282,6 +282,10 @@ def transform_error_basis(
         return g, np.zeros((0, num_cols), dtype=np.uint8)
 
     # Parse variable indices and find the dimension
+    for var in (var for v in parametrized_vertices for var in g._phaseVars[v]):
+        assert (
+            var.startswith("e") and var[1:].isdigit()
+        ), f"unexpected phase var {var!r}"
     error_indices = [
         [int(var[1:]) for var in g._phaseVars[v]] for v in parametrized_vertices
     ]

--- a/src/tsim/core/parse.py
+++ b/src/tsim/core/parse.py
@@ -262,7 +262,16 @@ def parse_stim_circuit(
             detector(b, targets)
             continue
         if name == "OBSERVABLE_INCLUDE":
-            targets = [t.value for t in instruction.targets_copy()]
+            targets_copy = instruction.targets_copy()
+            for t in targets_copy:
+                if not t.is_measurement_record_target:
+                    raise ValueError(
+                        f"OBSERVABLE_INCLUDE with Pauli targets is not "
+                        f"supported in Tsim (only measurement record targets "
+                        f"like rec[-1] are supported). Got instruction "
+                        f"{str(instruction)!r}"
+                    )
+            targets = [t.value for t in targets_copy]
             args = instruction.gate_args_copy()
             observable_include(b, targets, int(args[0]))
             continue

--- a/src/tsim/noise/channels.py
+++ b/src/tsim/noise/channels.py
@@ -29,7 +29,7 @@ class Channel:
 
     def __post_init__(self) -> None:
         """Validate channel probabilities."""
-        tol = 1e-12
+        tol = 1e-6
         if np.any(self.probs < -tol) or np.any(self.probs > 1.0 + tol):
             raise ValueError(f"Probabilities must lie in [0, 1], but got: {self.probs}")
         if not np.isclose(np.sum(self.probs), 1.0):

--- a/src/tsim/sampler.py
+++ b/src/tsim/sampler.py
@@ -533,18 +533,13 @@ class CompiledDetectorSampler(_CompiledSamplerBase):
 
         Raises:
             ValueError: If ``separate_observables`` is combined with
-                ``prepend_observables`` or ``append_observables``, or if both
-                ``prepend_observables`` and ``append_observables`` are set.
+                ``prepend_observables`` or ``append_observables``.
 
         """
         if separate_observables and (prepend_observables or append_observables):
             raise ValueError(
                 "Can't specify separate_observables=True with "
                 "append_observables=True or prepend_observables=True"
-            )
-        if prepend_observables and append_observables:
-            raise ValueError(
-                "Can't specify both prepend_observables=True and append_observables=True"
             )
 
         compute_reference = (
@@ -563,13 +558,15 @@ class CompiledDetectorSampler(_CompiledSamplerBase):
         else:
             samples = self._sample_batches(shots, batch_size)
 
-        if append_observables:
-            return _maybe_bit_pack(samples, bit_packed=bit_packed)
-
         num_detectors = self._num_detectors
         det_samples = samples[:, :num_detectors]
         obs_samples = samples[:, num_detectors:]
 
+        if prepend_observables and append_observables:
+            combined = np.concatenate([obs_samples, det_samples, obs_samples], axis=1)
+            return _maybe_bit_pack(combined, bit_packed=bit_packed)
+        if append_observables:
+            return _maybe_bit_pack(samples, bit_packed=bit_packed)
         if prepend_observables:
             combined = np.concatenate([obs_samples, det_samples], axis=1)
             return _maybe_bit_pack(combined, bit_packed=bit_packed)

--- a/src/tsim/utils/clifford.py
+++ b/src/tsim/utils/clifford.py
@@ -122,7 +122,7 @@ def is_clifford(source: stim.Circuit) -> bool:
         if instr.name == "I" and instr.tag:
             result = parse_parametric_tag(instr)
             if result is None:
-                return False
+                continue
 
             gate_name, params = result
             if gate_name in ["R_X", "R_Y", "R_Z"]:

--- a/src/tsim/utils/diagram.py
+++ b/src/tsim/utils/diagram.py
@@ -14,6 +14,7 @@ from pyzx_param.graph.graph_s import GraphS
 
 from tsim.core.graph import scale_horizontally
 from tsim.core.parse import parse_stim_circuit
+from tsim.utils.program_text import _FLOAT_RE
 
 
 class Diagram:
@@ -340,7 +341,7 @@ def _parse_parametric_tag(tag: str) -> tuple[str, dict[str, Fraction]] | None:
         param = param.strip()
         if not param:
             continue
-        param_match = re.match(r"^(\w+)=([-+]?[\d.]+)\*pi$", param)
+        param_match = re.match(rf"^(\w+)=({_FLOAT_RE})\*pi$", param)
         if not param_match:
             return None
         param_name = param_match.group(1)
@@ -419,24 +420,23 @@ def _replace_tagged_gates(
             if result is not None:
                 gate_name, params = result
 
+                if gate_name not in ("R_X", "R_Y", "R_Z", "U3"):
+                    # Unknown parametric gate, pass through unchanged.
+                    modified_circ.append(instr)
+                    continue
+
                 for target in instr.targets_copy():
                     identifier = np.round(np.random.rand(), 6)
 
-                    if gate_name in ["R_X", "R_Y", "R_Z"]:
+                    if gate_name in ("R_X", "R_Y", "R_Z"):
                         axis = gate_name[-1]
                         label = "R" + _subscript(axis)
                         theta = float(params["theta"])
                         annotation = f"{theta:.4g}π"
                         replace_dict[identifier] = GateLabel(label, annotation)
-
-                    elif gate_name == "U3":
+                    else:
                         label = "U" + _subscript("3")
                         replace_dict[identifier] = GateLabel(label, None)
-
-                    else:
-                        # Unknown parametric gate, pass through
-                        modified_circ.append(instr)
-                        continue
 
                     modified_circ.append("I_ERROR", [target], identifier)
                 continue

--- a/src/tsim/utils/diagram.py
+++ b/src/tsim/utils/diagram.py
@@ -14,7 +14,7 @@ from pyzx_param.graph.graph_s import GraphS
 
 from tsim.core.graph import scale_horizontally
 from tsim.core.parse import parse_stim_circuit
-from tsim.utils.program_text import _FLOAT_RE
+from tsim.utils.program_text import FLOAT_RE
 
 
 class Diagram:
@@ -341,7 +341,7 @@ def _parse_parametric_tag(tag: str) -> tuple[str, dict[str, Fraction]] | None:
         param = param.strip()
         if not param:
             continue
-        param_match = re.match(rf"^(\w+)=({_FLOAT_RE})\*pi$", param)
+        param_match = re.match(rf"^(\w+)=({FLOAT_RE})\*pi$", param)
         if not param_match:
             return None
         param_name = param_match.group(1)

--- a/src/tsim/utils/program_text.py
+++ b/src/tsim/utils/program_text.py
@@ -3,7 +3,7 @@
 import re
 
 # Matches valid numeric literals including scientific notation (e.g. 0.5, 4e-4, 1.2e3)
-_FLOAT_RE = r"[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?"
+FLOAT_RE = r"[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?"
 
 _TSIM_GATES = {"R_X", "R_Y", "R_Z", "U3"}
 _GATE_NOT_FOUND_RE = re.compile(r"Gate not found: '(\w+)'")
@@ -52,14 +52,14 @@ def shorthand_to_stim(text: str) -> str:
         axis = m.group(1)
         return f"I[R_{axis}(theta={float(m.group(2))}*pi)]"
 
-    text = re.sub(rf"\bR_([XYZ])\(({_FLOAT_RE})\)", replace_rotation, text)
+    text = re.sub(rf"\bR_([XYZ])\(({FLOAT_RE})\)", replace_rotation, text)
 
     def replace_u3(m: re.Match) -> str:
         theta, phi, lam = float(m.group(1)), float(m.group(2)), float(m.group(3))
         return f"I[U3(theta={theta}*pi, phi={phi}*pi, lambda={lam}*pi)]"
 
     text = re.sub(
-        rf"\bU3\(({_FLOAT_RE})\s*,\s*({_FLOAT_RE})\s*,\s*({_FLOAT_RE})\)",
+        rf"\bU3\(({FLOAT_RE})\s*,\s*({FLOAT_RE})\s*,\s*({FLOAT_RE})\)",
         replace_u3,
         text,
     )
@@ -85,7 +85,7 @@ def stim_to_shorthand(text: str) -> str:
         return f"U3({theta}, {phi}, {lam})"
 
     text = re.sub(
-        rf"\bI\[U3\(theta=({_FLOAT_RE})\*pi, phi=({_FLOAT_RE})\*pi, lambda=({_FLOAT_RE})\*pi\)\]",
+        rf"\bI\[U3\(theta=({FLOAT_RE})\*pi, phi=({FLOAT_RE})\*pi, lambda=({FLOAT_RE})\*pi\)\]",
         replace_u3,
         text,
     )
@@ -97,7 +97,7 @@ def stim_to_shorthand(text: str) -> str:
         return f"R_{axis}({angle})"
 
     text = re.sub(
-        rf"\bI\[R_([XYZ])\(theta=({_FLOAT_RE})\*pi\)\]",
+        rf"\bI\[R_([XYZ])\(theta=({FLOAT_RE})\*pi\)\]",
         replace_rotation,
         text,
     )

--- a/src/tsim/utils/program_text.py
+++ b/src/tsim/utils/program_text.py
@@ -64,6 +64,19 @@ def shorthand_to_stim(text: str) -> str:
         text,
     )
 
+    # Canonicalize literals inside already-expanded parametric tags so that
+    # equivalent inputs like `I[R_X(theta=0.5e-2*pi)]` and
+    # `I[R_X(theta=0.005*pi)]` produce the same stim tag string. This keeps
+    # `tsim.Circuit(str(c)) == c` round-trip stable across notations.
+    def _canonicalize_param(m: re.Match) -> str:
+        return f"{m.group(1)}={float(m.group(2))}*pi"
+
+    text = re.sub(
+        rf"\b(theta|phi|lambda)=({FLOAT_RE})\*pi",
+        _canonicalize_param,
+        text,
+    )
+
     return text
 
 

--- a/test/unit/core/test_parse.py
+++ b/test/unit/core/test_parse.py
@@ -730,6 +730,28 @@ class TestParseEmptyAnnotations:
         assert len(b.detectors) == 1
 
 
+class TestParseObservableIncludePauliTargets:
+    """OBSERVABLE_INCLUDE accepts Pauli targets in stim but Tsim only supports
+    measurement-record targets; reject Pauli targets explicitly rather than
+    silently mis-indexing into the measurement record."""
+
+    @pytest.mark.parametrize(
+        "program",
+        [
+            "H 1\nOBSERVABLE_INCLUDE(0) X1\nM 0",
+            "M 0 1\nH 0\nOBSERVABLE_INCLUDE(0) X1",
+            "M 0\nOBSERVABLE_INCLUDE(0) Z0",
+            "M 0 1\nOBSERVABLE_INCLUDE(0) rec[-1] Y1",
+        ],
+    )
+    def test_pauli_target_rejected(self, program):
+        with pytest.raises(ValueError, match="OBSERVABLE_INCLUDE with Pauli targets"):
+            parse_stim_circuit(stim.Circuit(program))
+
+    def test_record_targets_still_accepted(self):
+        parse_stim_circuit(stim.Circuit("M 0 1\nOBSERVABLE_INCLUDE(0) rec[-1] rec[-2]"))
+
+
 class TestParseMPPCancellation:
     """Tests for MPP with duplicate/anticommuting Pauli targets.
 

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -25,6 +25,9 @@ def test_detector_sampler_args():
     d = sampler.sample(1, prepend_observables=True)
     assert np.array_equal(d, np.array([[1, 0, 0]]))
 
+    d = sampler.sample(1, prepend_observables=True, append_observables=True)
+    assert np.array_equal(d, np.array([[1, 0, 0, 1]]))
+
     d, o = sampler.sample(1, separate_observables=True)
     assert np.array_equal(d, np.array([[0, 0]]))
     assert np.array_equal(o, np.array([[1]]))
@@ -48,10 +51,6 @@ def test_detector_sampler_args():
                 "prepend_observables": True,
             },
             "separate_observables",
-        ),
-        (
-            {"prepend_observables": True, "append_observables": True},
-            "prepend_observables",
         ),
     ],
 )

--- a/test/unit/utils/test_clifford.py
+++ b/test/unit/utils/test_clifford.py
@@ -184,3 +184,20 @@ class TestStimCircuitProperty:
         stim_str = str(c.stim_circuit)
         assert "I[" not in stim_str
         assert "Z 0 1 2" in stim_str
+
+
+class TestIsCliffordUserTags:
+    """Identity instructions with non-parametric user tags (e.g. ``I[mytag]``)
+    are still Clifford — only parametric rotation tags can flip the result.
+    """
+
+    @pytest.mark.parametrize(
+        "program",
+        [
+            "I[mytag] 0",
+            "I[abc123] 0",
+            "H 0\nI[mytag] 0\nCNOT 0 1\nM 0 1",
+        ],
+    )
+    def test_user_tag_is_clifford(self, program):
+        assert Circuit(program).is_clifford

--- a/test/unit/utils/test_diagram.py
+++ b/test/unit/utils/test_diagram.py
@@ -1,3 +1,4 @@
+from fractions import Fraction
 from typing import Literal
 
 import pytest
@@ -6,6 +7,7 @@ import stim
 from tsim.circuit import Circuit
 from tsim.utils.diagram import (
     GateLabel,
+    _parse_parametric_tag,
     _width_from_viewbox,
     placeholders_to_t,
     render_svg,
@@ -45,6 +47,44 @@ def test_tagged_gates_to_placeholder_adds_error_and_mapping():
     modified, placeholder_map = tagged_gates_to_placeholder(c)
     assert len(placeholder_map) == 1
     assert "I_ERROR" in str(modified)
+
+
+def test_tagged_gates_to_placeholder_passes_unknown_parametric_through_once():
+    c = stim.Circuit("I[XYZ(theta=0.1*pi)] 0 1 2")
+    modified, placeholder_map = tagged_gates_to_placeholder(c)
+    assert placeholder_map == {}
+    assert len(modified) == 1
+    instr = modified[0]
+    assert isinstance(instr, stim.CircuitInstruction)
+    assert instr.name == "I"
+    assert instr.tag == "XYZ(theta=0.1*pi)"
+    assert [t.qubit_value for t in instr.targets_copy()] == [0, 1, 2]
+
+
+def test_parse_parametric_tag_accepts_scientific_notation():
+    assert _parse_parametric_tag("R_Z(theta=2.5e-1*pi)") == (
+        "R_Z",
+        {"theta": Fraction(1, 4)},
+    )
+    assert _parse_parametric_tag("R_X(theta=1.5E+0*pi)") == (
+        "R_X",
+        {"theta": Fraction(3, 2)},
+    )
+    assert _parse_parametric_tag("R_Y(theta=-2.5e-1*pi)") == (
+        "R_Y",
+        {"theta": Fraction(-1, 4)},
+    )
+
+
+def test_tagged_gates_to_placeholder_handles_scientific_notation():
+    c = stim.Circuit("I[R_Z(theta=2.5e-1*pi)] 0")
+    modified, placeholder_map = tagged_gates_to_placeholder(c)
+    assert len(placeholder_map) == 1
+    label = next(iter(placeholder_map.values()))
+    assert "Z" in label.label  # R subscripted with Z
+    assert label.annotation == "0.25π"
+    assert len(modified) == 1
+    assert modified[0].name == "I_ERROR"
 
 
 def test_render_svg_wraps_when_width_given():

--- a/test/unit/utils/test_program_text.py
+++ b/test/unit/utils/test_program_text.py
@@ -102,6 +102,19 @@ def test_circuit_str_scientific_notation_roundtrip():
 
 
 @pytest.mark.parametrize(
+    "program",
+    [
+        "I[R_X(theta=0.5e-2*pi)] 0",
+        "I[R_Z(theta=4e-4*pi)] 1",
+        "I[U3(theta=0.1*pi, phi=2e-1*pi, lambda=0.3*pi)] 0",
+    ],
+)
+def test_circuit_eq_roundtrip_scientific_notation(program):
+    c1 = Circuit(program)
+    assert Circuit(str(c1)) == c1
+
+
+@pytest.mark.parametrize(
     "text, snippet",
     [
         ("R_Z(a) 0", "R_Z(a)"),


### PR DESCRIPTION
## Summary

Fixes a small batch of unrelated bugs across the sampler, parser, clifford, noise, diagram, and graph modules.

- **`CompiledDetectorSampler.sample`** — `prepend_observables=True` + `append_observables=True` previously raised; Stim accepts both and returns `[obs, det, obs]`. Removed the redundant guard and added the duplication path so column layout matches Stim exactly.
- **`OBSERVABLE_INCLUDE` with Pauli targets** — the parser blindly extracted `t.value` from every target. For a Pauli target like `X1`, `t.value` is the qubit index, which `observable_include` then dereferenced as a measurement-record index — silently producing wrong observable bits or crashing with `IndexError` depending on the value. Now raises `ValueError`; only measurement-record targets are supported by tsim.
- **`Channel.__post_init__`** — probability validation rejected vectors whose components summed to slightly more than 1 due to FP slop (e.g. `PAULI_CHANNEL_2(0.0666666667 ×15)` summing to `1.0000000005`). Stim accepts such inputs; tolerance widened from `1e-12` to `1e-6`.
- **`is_clifford`** — returned `False` for any `I` instruction with a non-parametric user tag (e.g. `I[mytag]`). `parse_parametric_tag` returns `None` for tags that don't match the `name(...)` shape, and that was being treated as a non-Clifford rotation. Now treated as a user label; the instruction remains Clifford.
- **`shorthand_to_stim`** — `tsim.Circuit(str(c)) == c` failed when a parametric tag used scientific notation, because the direct-expanded tag `I[R_X(theta=0.5e-2*pi)]` was preserved verbatim while the shorthand re-parse normalized through `float()` to `0.005`. Both paths now canonicalize parametric literals through `float()` so equality is round-trip stable.
- **`transform_error_basis`** — phase variable names were parsed via `int(var[1:])`, which silently aliased `m0`/`c5`/… to `e0`/`e5` and crashed on bracketed names like `rec[0]`. Now asserts each name matches `e<int>` so any future drift in upstream phase-var clearing fails loud.
- **`_collect_vertices`** — docstring claimed BFS but the implementation is DFS (`queue.pop()` from the right). Corrected the docstring; behavior unchanged.
- **`_replace_tagged_gates`** — unknown parametric tag (e.g. `I[XYZ(theta=0.1*pi)] 0 1 2`) was appended once per target, multiplying qubit references. The unknown-gate fallthrough is now lifted out of the per-target loop so the instruction is emitted once.
- **`_parse_parametric_tag`** — local regex rejected scientific-notation angles like `1e-7`. Now uses the shared `FLOAT_RE` from `program_text.py`, matching the round-trip parser.