### PR TITLE
Add CCZ and CCX gate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ An introductory tutorial is available [here](https://tsim.mintlify.app/tutorials
 
 For many existing scripts, replacing `stim` with `tsim` should just work. Tsim mirrors the Stim API and currently supports all [Stim instructions](https://github.com/quantumlib/Stim/wiki/Stim-v1.13-Gate-Reference).
 
-Additionally, Tsim supports the instructions `T`, `T_DAG`, `R_Z`, `R_X`, `R_Y`, `U3`, `TPP`, and `TPP_DAG`.
+Additionally, Tsim supports the instructions `T`, `T_DAG`, `R_Z`, `R_X`, `R_Y`, `U3`, `TPP`, `TPP_DAG`, `CCZ`, and `CCX`.
 ```python
 import tsim
 
@@ -142,6 +142,15 @@ U3(0.5, 0.25, 0.125) 0  # Apply U3 with θ=π/2, φ=π/4, λ=π/8
 ```
 TPP X0*Y1      # Apply exp(-i π/8 · X0⊗Y1) (up to global phase)
 TPP_DAG Z0     # Apply exp(+i π/8 · Z) = T_DAG (up to global phase)
+```
+
+### `CCZ` and `CCX` Gates
+
+`CCZ` applies a controlled-controlled Z gate, and `CCX` applies the controlled-controlled X gate (Toffoli). Both gates are expanded internally into a Clifford+T decomposition:
+
+```
+CCZ 0 1 2  # Apply CCZ with controls 0 and 1, target 2
+CCX 0 1 2  # Apply Toffoli/CCX with controls 0 and 1, target 2
 ```
 
 ## Publications Using Tsim

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ A detailed description of Tsim is given in [arXiv:2604.01059](https://arxiv.org/
 
 An introductory tutorial is available [here](demos/encoding_demo.ipynb). For many existing scripts, replacing `stim` with `tsim` should just work. Tsim mirrors the Stim API and supports all [Stim instructions](https://github.com/quantumlib/Stim/wiki/Stim-v1.13-Gate-Reference).
 
-Additionally, Tsim supports the instructions `T`, `T_DAG`, `R_Z`, `R_X`, `R_Y`, and `U3`.
+Additionally, Tsim supports the instructions `T`, `T_DAG`, `R_Z`, `R_X`, `R_Y`, `U3`, `CCZ`, and `CCX`.
 
 ```python
 import tsim

--- a/src/tsim/circuit.py
+++ b/src/tsim/circuit.py
@@ -25,10 +25,36 @@ from tsim.noise.dem import get_detector_error_model
 from tsim.utils.clifford import expand_clifford_rotations, is_clifford
 from tsim.utils.diagram import render_pyzx_d3, render_svg
 from tsim.utils.program_text import (
+    controlled_gate_decomposition_lines,
     enriched_stim_error,
     shorthand_to_stim,
     stim_to_shorthand,
 )
+
+
+def _bare_qubit_targets(
+    gate_name: str,
+    targets: (
+        int
+        | stim.GateTarget
+        | stim.PauliString
+        | Iterable[int | stim.GateTarget | stim.PauliString]
+    ),
+) -> list[int]:
+    if isinstance(targets, int | stim.GateTarget | stim.PauliString):
+        target_items: list[int | stim.GateTarget | stim.PauliString] = [targets]
+    else:
+        target_items = list(targets)
+
+    qubits: list[int] = []
+    for target in target_items:
+        if isinstance(target, int):
+            qubits.append(target)
+        elif isinstance(target, stim.GateTarget) and target.is_qubit_target:
+            qubits.append(target.value)
+        else:
+            raise ValueError(f"{gate_name} only supports bare qubit targets.")
+    return qubits
 
 
 class Circuit:
@@ -150,6 +176,27 @@ class Circuit:
 
         """
         if isinstance(name, str):
+            if name in ("CCZ", "CCX"):
+                if arg is not None:
+                    raise ValueError(f"For {name} gates, no arguments are accepted.")
+                if tag:
+                    raise ValueError(f"For {name} gates, tags are not supported.")
+                qubits = _bare_qubit_targets(name, targets)
+                if len(qubits) % 3 != 0:
+                    raise ValueError(
+                        f"{name} expects qubit targets in groups of three."
+                    )
+                self.append_from_stim_program_text(
+                    "\n".join(
+                        line
+                        for i in range(0, len(qubits), 3)
+                        for line in controlled_gate_decomposition_lines(
+                            name, qubits[i], qubits[i + 1], qubits[i + 2]
+                        )
+                    )
+                )
+                return
+
             if name == "TPP":
                 name = "SPP"
                 tag = "T"

--- a/src/tsim/circuit.py
+++ b/src/tsim/circuit.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 from tsim.core.graph import build_sampling_graph
 from tsim.core.parse import parse_parametric_tag, parse_stim_circuit
+from tsim.core.tags import encode_t_tag
 from tsim.noise.dem import get_detector_error_model
 from tsim.utils.clifford import expand_clifford_rotations, is_clifford
 from tsim.utils.diagram import render_pyzx_d3, render_svg
@@ -179,8 +180,6 @@ class Circuit:
             if name in ("CCZ", "CCX"):
                 if arg is not None:
                     raise ValueError(f"For {name} gates, no arguments are accepted.")
-                if tag:
-                    raise ValueError(f"For {name} gates, tags are not supported.")
                 qubits = _bare_qubit_targets(name, targets)
                 if len(qubits) % 3 != 0:
                     raise ValueError(
@@ -191,7 +190,7 @@ class Circuit:
                         line
                         for i in range(0, len(qubits), 3)
                         for line in controlled_gate_decomposition_lines(
-                            name, qubits[i], qubits[i + 1], qubits[i + 2]
+                            name, qubits[i], qubits[i + 1], qubits[i + 2], tag=tag
                         )
                     )
                 )
@@ -199,16 +198,16 @@ class Circuit:
 
             if name == "TPP":
                 name = "SPP"
-                tag = "T"
+                tag = encode_t_tag(tag)
             elif name == "TPP_DAG":
                 name = "SPP_DAG"
-                tag = "T"
+                tag = encode_t_tag(tag)
             elif name == "T":
                 name = "S"
-                tag = "T"
+                tag = encode_t_tag(tag)
             elif name == "T_DAG":
                 name = "S_DAG"
-                tag = "T"
+                tag = encode_t_tag(tag)
             elif name in ("R_X", "R_Y", "R_Z"):
                 if arg is None:
                     raise ValueError(f"For {name} gates, an angle must be provided.")

--- a/src/tsim/core/parse.py
+++ b/src/tsim/core/parse.py
@@ -24,6 +24,7 @@ from tsim.core.instructions import (
     tpp,
     u3,
 )
+from tsim.core.tags import is_t_tag
 
 _PARAMETRIC_GATE_PARAMS: dict[str, frozenset[str]] = {
     "R_X": frozenset({"theta"}),
@@ -192,9 +193,9 @@ def parse_stim_circuit(
                 f"in instruction {str(instruction)!r}"
             )
 
-        if name == "S" and instruction.tag == "T":
+        if name == "S" and is_t_tag(instruction.tag):
             name = "T"
-        elif name == "S_DAG" and instruction.tag == "T":
+        elif name == "S_DAG" and is_t_tag(instruction.tag):
             name = "T_DAG"
 
         # Handle parametric gates via tags (e.g., I with tag "R_Z(theta=0.3*pi)")
@@ -225,7 +226,7 @@ def parse_stim_circuit(
             for paulis, invert in _iter_pauli_products(instruction):
                 mpp(b, paulis, invert, p=p)
             continue
-        if name in ("SPP", "SPP_DAG") and instruction.tag == "T":
+        if name in ("SPP", "SPP_DAG") and is_t_tag(instruction.tag):
             is_dag = name == "SPP_DAG"
             for paulis, invert in _iter_pauli_products(instruction):
                 tpp(b, paulis, dagger=is_dag ^ invert)

--- a/src/tsim/core/tags.py
+++ b/src/tsim/core/tags.py
@@ -1,0 +1,25 @@
+"""Helpers for tags that encode tsim-specific gate metadata."""
+
+T_TAG = "T"
+_T_USER_TAG_PREFIX = f"{T_TAG}:"
+
+
+def encode_t_tag(user_tag: str = "") -> str:
+    """Encode a T-family gate tag while preserving an optional user tag."""
+    if not user_tag:
+        return T_TAG
+    return f"{_T_USER_TAG_PREFIX}{user_tag}"
+
+
+def is_t_tag(tag: str) -> bool:
+    """Return whether a Stim tag encodes a tsim T-family gate."""
+    return tag == T_TAG or tag.startswith(_T_USER_TAG_PREFIX)
+
+
+def decode_t_user_tag(tag: str) -> str:
+    """Return the user tag attached to an encoded T-family gate tag."""
+    if tag == T_TAG:
+        return ""
+    if tag.startswith(_T_USER_TAG_PREFIX):
+        return tag[len(_T_USER_TAG_PREFIX) :]
+    raise ValueError(f"Tag does not encode a T-family gate: {tag!r}")

--- a/src/tsim/external/vec_sim/vec_sampler.py
+++ b/src/tsim/external/vec_sim/vec_sampler.py
@@ -18,6 +18,7 @@ import numpy as np
 import stim
 
 from tsim.core.parse import parse_parametric_tag
+from tsim.core.tags import is_t_tag
 from tsim.external.vec_sim import VecSim
 
 
@@ -74,10 +75,10 @@ def sample_circuit_with_vec_sim_return_data(
         sim.do_qalloc_z(q)
     for inst in circuit:
         assert not isinstance(inst, stim.CircuitRepeatBlock)
-        if inst.name == "S" and inst.tag == "T":
+        if inst.name == "S" and is_t_tag(inst.tag):
             for q in inst.targets_copy():
                 sim.do_t(q.qubit_value)
-        elif inst.name == "S_DAG" and inst.tag == "T":
+        elif inst.name == "S_DAG" and is_t_tag(inst.tag):
             for q in inst.targets_copy():
                 sim.do_t_dag(q.qubit_value)
         elif inst.name == "I" and inst.tag:

--- a/src/tsim/utils/clifford.py
+++ b/src/tsim/utils/clifford.py
@@ -7,6 +7,7 @@ from fractions import Fraction
 import stim
 
 from tsim.core.parse import parse_parametric_tag
+from tsim.core.tags import is_t_tag
 
 # Clifford decompositions for U3(θ, φ, λ) = R_Z(φ) · R_Y(θ) · R_Z(λ).
 # Keys: (θ_idx, φ_idx, λ_idx) where each index ∈ {0,1,2,3} is the angle in half-pi units.
@@ -116,7 +117,7 @@ def is_clifford(source: stim.Circuit) -> bool:
                 return False
             continue
 
-        if instr.name in ["S", "S_DAG", "SPP", "SPP_DAG"] and instr.tag == "T":
+        if instr.name in ["S", "S_DAG", "SPP", "SPP_DAG"] and is_t_tag(instr.tag):
             return False
 
         if instr.name == "I" and instr.tag:

--- a/src/tsim/utils/diagram.py
+++ b/src/tsim/utils/diagram.py
@@ -14,6 +14,7 @@ from pyzx_param.graph.graph_s import GraphS
 
 from tsim.core.graph import scale_horizontally
 from tsim.core.parse import parse_stim_circuit
+from tsim.core.tags import is_t_tag
 from tsim.utils.program_text import FLOAT_RE
 
 
@@ -390,7 +391,7 @@ def _replace_tagged_gates(
         # Double each Pauli target so the SVG contains duplicate rect+text
         # pairs at the same position, which _deduplicate_doubled_spp() later
         # detects and renames SPP → TPP.
-        if instr.tag == "T" and instr.name in ["SPP", "SPP_DAG"]:
+        if is_t_tag(instr.tag) and instr.name in ["SPP", "SPP_DAG"]:
             targets = instr.targets_copy()
             doubled: list[stim.GateTarget] = []
             for target in targets:
@@ -405,7 +406,7 @@ def _replace_tagged_gates(
             continue
 
         # Handle T gates (S[T] and S_DAG[T])
-        if instr.tag == "T" and instr.name in ["S", "S_DAG"]:
+        if is_t_tag(instr.tag) and instr.name in ["S", "S_DAG"]:
             for target in instr.targets_copy():
                 identifier = np.round(np.random.rand(), 6)
                 DAG = '<tspan baseline-shift="super" font-size="14">†</tspan>'

--- a/src/tsim/utils/program_text.py
+++ b/src/tsim/utils/program_text.py
@@ -5,9 +5,70 @@ import re
 # Matches valid numeric literals including scientific notation (e.g. 0.5, 4e-4, 1.2e3)
 FLOAT_RE = r"[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?"
 
-_TSIM_GATES = {"R_X", "R_Y", "R_Z", "U3"}
+_TSIM_GATES = {"CCZ", "CCX", "R_X", "R_Y", "R_Z", "U3"}
 _GATE_NOT_FOUND_RE = re.compile(r"Gate not found: '(\w+)'")
-_GATE_USAGE_RE = re.compile(r"(?<!\[)\b(R_[A-Z]\([^)]*\)|R_[XYZ]\b|U3\([^)]*\)|U3\b)")
+_GATE_USAGE_RE = re.compile(
+    r"(?<!\[)\b(CCZ\b|CCX\b|R_[A-Z]\([^)]*\)|R_[XYZ]\b|U3\([^)]*\)|U3\b)"
+)
+
+
+def controlled_gate_decomposition_lines(
+    gate: str,
+    control1: int | str,
+    control2: int | str,
+    target: int | str,
+) -> list[str]:
+    """Return a Clifford+T decomposition for a controlled-controlled gate."""
+    if gate not in ("CCZ", "CCX"):
+        raise ValueError(f"Unsupported controlled-controlled gate: {gate!r}")
+
+    a, b, c = str(control1), str(control2), str(target)
+    ccz_lines = [
+        f"CNOT {b} {c}",
+        f"T_DAG {c}",
+        f"CNOT {a} {c}",
+        f"T {c}",
+        f"CNOT {b} {c}",
+        f"T_DAG {c}",
+        f"CNOT {a} {c}",
+        f"T {b}",
+        f"T {c}",
+        f"CNOT {a} {b}",
+        f"T {a}",
+        f"T_DAG {b}",
+        f"CNOT {a} {b}",
+    ]
+    if gate == "CCZ":
+        return ccz_lines
+    return [f"H {c}", *ccz_lines, f"H {c}"]
+
+
+def _expand_controlled_gates(text: str) -> str:
+    lines: list[str] = []
+    for line in text.splitlines():
+        body, sep, comment = line.partition("#")
+        match = re.match(r"^(\s*)(CCZ|CCX)\s+(.+?)\s*$", body)
+        if not match:
+            lines.append(line)
+            continue
+
+        indent, gate, targets_text = match.groups()
+        targets = targets_text.split()
+        if len(targets) % 3 != 0 or not all(target.isdecimal() for target in targets):
+            raise ValueError(
+                f"{gate} expects bare qubit integer targets in groups of three."
+            )
+
+        if sep:
+            lines.append(f"{indent}{sep}{comment}")
+        for i in range(0, len(targets), 3):
+            lines.extend(
+                f"{indent}{decomp_line}"
+                for decomp_line in controlled_gate_decomposition_lines(
+                    gate, targets[i], targets[i + 1], targets[i + 2]
+                )
+            )
+    return "\n".join(lines)
 
 
 def enriched_stim_error(exc: ValueError, converted_text: str) -> ValueError:
@@ -31,6 +92,8 @@ def shorthand_to_stim(text: str) -> str:
     """Convert tsim shorthand syntax to valid stim instructions.
 
     Converts:
+        CCZ 0 1 2           → Clifford+T decomposition of CCZ
+        CCX 0 1 2           → Clifford+T decomposition of CCX/Toffoli
         T 0 1               → S[T] 0 1
         T_DAG 0 1           → S_DAG[T] 0 1
         TPP X0*Y1           → SPP[T] X0*Y1
@@ -41,6 +104,8 @@ def shorthand_to_stim(text: str) -> str:
         U3(0.3, 0.24, 0.49) 0 → I[U3(theta=0.3*pi, phi=0.24*pi, lambda=0.49*pi)] 0
 
     """
+    text = _expand_controlled_gates(text)
+
     # TPP_DAG/TPP must come before T_DAG/T to avoid partial matches
     # (?<!\[) ensures we don't match T inside [T]
     text = re.sub(r"(?<!\[)\bTPP_DAG\b(?!\[)", "SPP_DAG[T]", text)

--- a/src/tsim/utils/program_text.py
+++ b/src/tsim/utils/program_text.py
@@ -1,6 +1,9 @@
 """Conversion utilities between tsim shorthand and stim program text."""
 
 import re
+from collections.abc import Callable
+
+from tsim.core.tags import decode_t_user_tag, encode_t_tag
 
 # Matches valid numeric literals including scientific notation (e.g. 0.5, 4e-4, 1.2e3)
 FLOAT_RE = r"[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?"
@@ -17,42 +20,47 @@ def controlled_gate_decomposition_lines(
     control1: int | str,
     control2: int | str,
     target: int | str,
+    *,
+    tag: str = "",
 ) -> list[str]:
     """Return a Clifford+T decomposition for a controlled-controlled gate."""
     if gate not in ("CCZ", "CCX"):
         raise ValueError(f"Unsupported controlled-controlled gate: {gate!r}")
 
+    def tagged(name: str) -> str:
+        return f"{name}[{tag}]" if tag else name
+
     a, b, c = str(control1), str(control2), str(target)
     ccz_lines = [
-        f"CNOT {b} {c}",
-        f"T_DAG {c}",
-        f"CNOT {a} {c}",
-        f"T {c}",
-        f"CNOT {b} {c}",
-        f"T_DAG {c}",
-        f"CNOT {a} {c}",
-        f"T {b}",
-        f"T {c}",
-        f"CNOT {a} {b}",
-        f"T {a}",
-        f"T_DAG {b}",
-        f"CNOT {a} {b}",
+        f"{tagged('CNOT')} {b} {c}",
+        f"{tagged('T_DAG')} {c}",
+        f"{tagged('CNOT')} {a} {c}",
+        f"{tagged('T')} {c}",
+        f"{tagged('CNOT')} {b} {c}",
+        f"{tagged('T_DAG')} {c}",
+        f"{tagged('CNOT')} {a} {c}",
+        f"{tagged('T')} {b}",
+        f"{tagged('T')} {c}",
+        f"{tagged('CNOT')} {a} {b}",
+        f"{tagged('T')} {a}",
+        f"{tagged('T_DAG')} {b}",
+        f"{tagged('CNOT')} {a} {b}",
     ]
     if gate == "CCZ":
         return ccz_lines
-    return [f"H {c}", *ccz_lines, f"H {c}"]
+    return [f"{tagged('H')} {c}", *ccz_lines, f"{tagged('H')} {c}"]
 
 
 def _expand_controlled_gates(text: str) -> str:
     lines: list[str] = []
     for line in text.splitlines():
         body, sep, comment = line.partition("#")
-        match = re.match(r"^(\s*)(CCZ|CCX)\s+(.+?)\s*$", body)
+        match = re.match(r"^(\s*)(CCZ|CCX)(?:\[([^\]\n]*)\])?\s+(.+?)\s*$", body)
         if not match:
             lines.append(line)
             continue
 
-        indent, gate, targets_text = match.groups()
+        indent, gate, tag, targets_text = match.groups()
         targets = targets_text.split()
         if len(targets) % 3 != 0 or not all(target.isdecimal() for target in targets):
             raise ValueError(
@@ -65,10 +73,26 @@ def _expand_controlled_gates(text: str) -> str:
             lines.extend(
                 f"{indent}{decomp_line}"
                 for decomp_line in controlled_gate_decomposition_lines(
-                    gate, targets[i], targets[i + 1], targets[i + 2]
+                    gate, targets[i], targets[i + 1], targets[i + 2], tag=tag or ""
                 )
             )
     return "\n".join(lines)
+
+
+def _replace_t_family(stim_gate: str) -> Callable[[re.Match[str]], str]:
+    def replace(m: re.Match[str]) -> str:
+        return f"{stim_gate}[{encode_t_tag(m.group(1) or '')}]"
+
+    return replace
+
+
+def _replace_t_family_shorthand(tsim_gate: str) -> Callable[[re.Match[str]], str]:
+    def replace(m: re.Match[str]) -> str:
+        user_tag = decode_t_user_tag(m.group(1))
+        tag_suffix = f"[{user_tag}]" if user_tag else ""
+        return f"{tsim_gate}{tag_suffix}"
+
+    return replace
 
 
 def enriched_stim_error(exc: ValueError, converted_text: str) -> ValueError:
@@ -108,10 +132,26 @@ def shorthand_to_stim(text: str) -> str:
 
     # TPP_DAG/TPP must come before T_DAG/T to avoid partial matches
     # (?<!\[) ensures we don't match T inside [T]
-    text = re.sub(r"(?<!\[)\bTPP_DAG\b(?!\[)", "SPP_DAG[T]", text)
-    text = re.sub(r"(?<!\[)\bTPP\b(?!\[)", "SPP[T]", text)
-    text = re.sub(r"(?<!\[)\bT_DAG\b(?!\[)", "S_DAG[T]", text)
-    text = re.sub(r"(?<!\[)\bT\b(?!\[)", "S[T]", text)
+    text = re.sub(
+        r"(?<!\[)\bTPP_DAG(?:\[([^\]\n]*)\])?(?!\w)",
+        _replace_t_family("SPP_DAG"),
+        text,
+    )
+    text = re.sub(
+        r"(?<!\[)\bTPP(?:\[([^\]\n]*)\])?(?!\w)",
+        _replace_t_family("SPP"),
+        text,
+    )
+    text = re.sub(
+        r"(?<!\[)\bT_DAG(?:\[([^\]\n]*)\])?(?!\w)",
+        _replace_t_family("S_DAG"),
+        text,
+    )
+    text = re.sub(
+        r"(?<!\[)\bT(?:\[([^\]\n]*)\])?(?!\w)",
+        _replace_t_family("S"),
+        text,
+    )
 
     def replace_rotation(m: re.Match) -> str:
         axis = m.group(1)
@@ -182,12 +222,28 @@ def stim_to_shorthand(text: str) -> str:
 
     # Replace SPP[T] and SPP_DAG[T] with TPP and TPP_DAG
     # Must come before S[T]/S_DAG[T] to avoid partial matches
-    text = re.sub(r"(?<!\w)SPP_DAG\[T\](?!\w)", "TPP_DAG", text)
-    text = re.sub(r"(?<!\w)SPP\[T\](?!\w)", "TPP", text)
+    text = re.sub(
+        r"(?<!\w)SPP_DAG\[(T(?::[^\]\n]*)?)\](?!\w)",
+        _replace_t_family_shorthand("TPP_DAG"),
+        text,
+    )
+    text = re.sub(
+        r"(?<!\w)SPP\[(T(?::[^\]\n]*)?)\](?!\w)",
+        _replace_t_family_shorthand("TPP"),
+        text,
+    )
 
     # Replace S[T] and S_DAG[T] with T and T_DAG
     # Use non-word lookarounds because trailing ] is not a word character.
-    text = re.sub(r"(?<!\w)S_DAG\[T\](?!\w)", "T_DAG", text)
-    text = re.sub(r"(?<!\w)S\[T\](?!\w)", "T", text)
+    text = re.sub(
+        r"(?<!\w)S_DAG\[(T(?::[^\]\n]*)?)\](?!\w)",
+        _replace_t_family_shorthand("T_DAG"),
+        text,
+    )
+    text = re.sub(
+        r"(?<!\w)S\[(T(?::[^\]\n]*)?)\](?!\w)",
+        _replace_t_family_shorthand("T"),
+        text,
+    )
 
     return text

--- a/test/unit/test_circuit.py
+++ b/test/unit/test_circuit.py
@@ -154,6 +154,44 @@ def test_ccz_ccx_shorthand_and_append():
     assert c1._stim_circ == c2._stim_circ
 
 
+def test_tagged_ccx_shorthand_expands_with_tags():
+    c = Circuit("""
+        X 0
+        CCX[tag] 0 1 2
+        M 2
+        """)
+    assert str(c) == "\n".join(
+        [
+            "X 0",
+            "H[tag] 2",
+            "CX[tag] 1 2",
+            "T_DAG[tag] 2",
+            "CX[tag] 0 2",
+            "T[tag] 2",
+            "CX[tag] 1 2",
+            "T_DAG[tag] 2",
+            "CX[tag] 0 2",
+            "T[tag] 1 2",
+            "CX[tag] 0 1",
+            "T[tag] 0",
+            "T_DAG[tag] 1",
+            "CX[tag] 0 1",
+            "H[tag] 2",
+            "M 2",
+        ]
+    )
+
+
+def test_tagged_controlled_gate_append_matches_shorthand():
+    c1 = Circuit("CCZ[tag] 0 1 2\nCCX[tag] 0 1 2")
+
+    c2 = Circuit()
+    c2.append("CCZ", [0, 1, 2], tag="tag")
+    c2.append("CCX", [0, 1, 2], tag="tag")
+
+    assert c1._stim_circ == c2._stim_circ
+
+
 def test_ccz_gate_matrix():
     c = Circuit("CCZ 0 1 2")
     ccz_matrix = np.eye(8, dtype=complex)
@@ -163,6 +201,23 @@ def test_ccz_gate_matrix():
 
 def test_ccx_gate_matrix():
     c = Circuit("CCX 0 1 2")
+    ccx_matrix = np.eye(8, dtype=complex)
+    ccx_matrix[6, 6] = 0
+    ccx_matrix[7, 7] = 0
+    ccx_matrix[6, 7] = 1
+    ccx_matrix[7, 6] = 1
+    assert unitaries_equal_up_to_global_phase(c.to_matrix(), ccx_matrix)
+
+
+def test_tagged_ccz_gate_matrix():
+    c = Circuit("CCZ[tag] 0 1 2")
+    ccz_matrix = np.eye(8, dtype=complex)
+    ccz_matrix[-1, -1] = -1
+    assert unitaries_equal_up_to_global_phase(c.to_matrix(), ccz_matrix)
+
+
+def test_tagged_ccx_gate_matrix():
+    c = Circuit("CCX[tag] 0 1 2")
     ccx_matrix = np.eye(8, dtype=complex)
     ccx_matrix[6, 6] = 0
     ccx_matrix[7, 7] = 0

--- a/test/unit/test_circuit.py
+++ b/test/unit/test_circuit.py
@@ -143,6 +143,34 @@ def test_u3_gate_shorthand():
     assert c1._stim_circ == c2._stim_circ
 
 
+def test_ccz_ccx_shorthand_and_append():
+    """Test that CCZ/CCX shorthand matches append behavior."""
+    c1 = Circuit("CCZ 0 1 2\nCCX 0 1 2")
+
+    c2 = Circuit()
+    c2.append("CCZ", [0, 1, 2])
+    c2.append("CCX", [0, 1, 2])
+
+    assert c1._stim_circ == c2._stim_circ
+
+
+def test_ccz_gate_matrix():
+    c = Circuit("CCZ 0 1 2")
+    ccz_matrix = np.eye(8, dtype=complex)
+    ccz_matrix[-1, -1] = -1
+    assert unitaries_equal_up_to_global_phase(c.to_matrix(), ccz_matrix)
+
+
+def test_ccx_gate_matrix():
+    c = Circuit("CCX 0 1 2")
+    ccx_matrix = np.eye(8, dtype=complex)
+    ccx_matrix[6, 6] = 0
+    ccx_matrix[7, 7] = 0
+    ccx_matrix[6, 7] = 1
+    ccx_matrix[7, 6] = 1
+    assert unitaries_equal_up_to_global_phase(c.to_matrix(), ccx_matrix)
+
+
 @pytest.mark.parametrize(
     "stim_gate",
     [

--- a/test/unit/utils/test_program_text.py
+++ b/test/unit/utils/test_program_text.py
@@ -15,6 +15,12 @@ def test_shorthand_to_stim_t_and_t_dag():
     assert shorthand_to_stim(text) == expected
 
 
+def test_shorthand_to_stim_tagged_t_and_t_dag():
+    text = "T[phase] 0\nT_DAG[phase] 1"
+    expected = "S[T:phase] 0\nS_DAG[T:phase] 1"
+    assert shorthand_to_stim(text) == expected
+
+
 def test_shorthand_to_stim_tpp_and_tpp_dag():
     text = "TPP X0*Y1\nTPP_DAG Z0"
     expected = "SPP[T] X0*Y1\nSPP_DAG[T] Z0"
@@ -49,6 +55,12 @@ def test_shorthand_to_stim_u3():
 def test_stim_to_shorthand_t_and_t_dag():
     text = "S[T] 0 1\nS_DAG[T] 2"
     expected = "T 0 1\nT_DAG 2"
+    assert stim_to_shorthand(text) == expected
+
+
+def test_stim_to_shorthand_tagged_t_and_t_dag():
+    text = "S[T:phase] 0\nS_DAG[T:phase] 1"
+    expected = "T[phase] 0\nT_DAG[phase] 1"
     assert stim_to_shorthand(text) == expected
 
 


### PR DESCRIPTION
Closes #113.

## Summary

- Add `CCZ` and `CCX`/Toffoli support by expanding both program-text shorthand and `Circuit.append()` calls into the existing Clifford+T instruction set.
- Use the 7-T `CCZ` decomposition discussed in the issue, with `CCX` derived by H-conjugating the target.
- Add matrix truth-table coverage for `CCZ` and `CCX`, plus shorthand-vs-append coverage.
- Update the README and docs quick-start supported-instruction lists.

## Scope note

Visualization support is left out intentionally, matching the issue discussion that SVG visualization can be deferred.

## Validation

- `PYTHONPATH=src uv run pytest -q` -> `1087 passed in 46.24s`
- `PYTHONPATH=src uv run pytest test/unit/test_circuit.py -q` -> `192 passed in 1.22s`
- `PYTHONPATH=src uv run pytest test/integration/test_gate_unitaries.py -q` -> `117 passed in 2.27s`
- `PYTHONPATH=src uv run ruff check src/tsim/utils/program_text.py src/tsim/circuit.py test/unit/test_circuit.py` -> `All checks passed!`
- `PYTHONPATH=src uv run black --check src/tsim/utils/program_text.py src/tsim/circuit.py test/unit/test_circuit.py` -> `3 files would be left unchanged`
- `PYTHONPATH=src uv run pyright src/tsim/circuit.py src/tsim/utils/program_text.py test/unit/test_circuit.py` -> `0 errors, 0 warnings, 0 informations`

Note: in my local checkout, bare `uv run pytest` did not put `src/` on `sys.path`, so I used `PYTHONPATH=src` for the validation commands above.

## AI disclosure

AI-assisted with OpenAI Codex; the diff was reviewed and locally verified before submission.