### PR TITLE
Add ipywidgets as a runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 
 dependencies = [
     "equinox>=0.11.0",
+    "ipywidgets>=8.0.0",
     "jax>=0.4.38",
     "lxml>=5.0.0",
     "numpy>=1.25.0",
@@ -79,7 +80,6 @@ dev = [
     "sinter~=1.16.dev",
     "tesseract-decoder>=0.1.1.dev20251113222502",
     "tqdm>=4.67.1",
-    "ipywidgets>=8.0.0",
     "vulture>=2.16",
     "radon>=6.0.1",
 ]
@@ -162,6 +162,9 @@ extend_exclude = [
     "^docs/",
     "^test/",
 ]
+
+[tool.deptry.per_rule_ignores]
+DEP002 = ["ipywidgets"]
 
 [tool.vulture]
 paths = ["src", "test"]

--- a/uv.lock
+++ b/uv.lock
@@ -146,6 +146,7 @@ version = "0.2.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "equinox" },
+    { name = "ipywidgets" },
     { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "jax", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "lxml" },
@@ -176,7 +177,6 @@ dev = [
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "ipywidgets" },
     { name = "isort" },
     { name = "jupytext" },
     { name = "matplotlib" },
@@ -212,6 +212,7 @@ doc = [
 [package.metadata]
 requires-dist = [
     { name = "equinox", specifier = ">=0.11.0" },
+    { name = "ipywidgets", specifier = ">=8.0.0" },
     { name = "jax", specifier = ">=0.4.38" },
     { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda12'", specifier = ">=0.4.38" },
     { name = "jax", extras = ["cuda13"], marker = "extra == 'cuda13'", specifier = ">=0.6.0" },
@@ -231,7 +232,6 @@ dev = [
     { name = "galois", specifier = ">=0.4.10" },
     { name = "ipykernel", specifier = ">=6.1.0" },
     { name = "ipython", specifier = ">=8.29.0" },
-    { name = "ipywidgets", specifier = ">=8.0.0" },
     { name = "isort", specifier = ">=5.13.2" },
     { name = "jupytext", specifier = ">=1.17.2" },
     { name = "matplotlib", specifier = ">=3.10.7" },


### PR DESCRIPTION
## Summary

- promote `ipywidgets>=8.0.0` from the development group to runtime dependencies
- update `uv.lock` package metadata
- add a narrow deptry exception for the intentionally transitive dependency

## Motivation

`pyzx-param` imports `ipywidgets` when running in notebook mode. Without an explicit runtime dependency, importing tsim from a notebook can fail even though tsim itself is installed.

Closes #176.

## Validation

- `uv lock --check`
- `uv run deptry .`
- import smoke test for `ipywidgets` and `tsim`
- built wheel metadata contains `Requires-Dist: ipywidgets>=8.0.0`
- pre-commit packaging checks passed

The full pre-commit run still reports four existing Pyright errors in `test/unit/benchmarks/clifft_benchmarks.py` for the `batch_size` argument; those files are unrelated to this packaging-only change.