### PR TITLE
Fix first-interaction v3 workflow inputs

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_message: |
             👋 Thanks for opening your first pull request against **Tsim**!
 
             A quick note on contribution terms: by submitting this PR you
@@ -37,7 +37,7 @@ jobs:
               for commit messages.
 
             We'll get to your PR as soon as we can. Thanks for contributing!
-          issue-message: |
+          issue_message: |
             👋 Thanks for opening your first issue against **Tsim**!
 
             A maintainer will take a look soon. To help us resolve it


### PR DESCRIPTION
## Summary

- rename the three `actions/first-interaction@v3` inputs to the v3 names
- keep the workflow behavior and messages unchanged

## Root cause

The v1-to-v3 action bump updated the action reference but retained v1 input names. v3 requires `repo_token`, `pr_message`, and `issue_message`; the old hyphenated names are ignored, causing the welcome job to fail with `Input required and not supplied: issue_message`.

## Validation

- confirmed the input names against `actions/first-interaction@v3` metadata
- YAML pre-commit hook passed
- diff check passed
- codespell and dependency checks passed

The repository's existing Pyright hook still reports four unrelated `batch_size` errors in `test/unit/benchmarks/clifft_benchmarks.py`.