### PR TITLE
Stabilize Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,12 @@ jobs:
         # For example, using `pytest`
         run: uv run just coverage
       - name: Upload Coverage to Codecov
+        if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v7
         with:
           files: coverage.xml # optional
           fail_ci_if_error: true # optional (default = false)
+          use_pypi: true
           verbose: true # optional (default = false)
           token: ${{ secrets.CODECOV_TOKEN }} # required
       - name: Archive code coverage results


### PR DESCRIPTION
## Summary

- upload coverage to Codecov only from the Python 3.12 matrix job
- install the Codecov CLI from PyPI to avoid the flaky Keybase/GPG download path
- keep `fail_ci_if_error: true` so genuine upload failures still fail CI

## Root cause

The test suite was passing, but one matrix job would intermittently fail while `codecov/codecov-action@v7` fetched and imported its GPG public key. The failed key response produced `gpg: no valid OpenPGP data found`, and rerunning succeeded after the upstream endpoint recovered.

Running four identical coverage uploads increased exposure to that external failure and made it appear tied to whichever Python job encountered it.

## Impact

Coverage is uploaded once from Python 3.12, which is already the job that archives `coverage.xml`. The PR coverage-comment job and the full Python test matrix remain unchanged.

## Validation

- workflow YAML parses successfully
- YAML, whitespace, spelling, and dependency pre-commit hooks pass
- independent review found no workflow or Codecov input issues
- the repository-wide Pyright hook remains blocked by four pre-existing `batch_size` errors in `test/unit/benchmarks/clifft_benchmarks.py`, unrelated to this workflow-only change
