### PR TITLE
Prepare 0.1.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-07-21
+
 ### Added
-- `R_XX`, `R_YY`, `R_ZZ`, and `R_PAULI` parametric Pauli-product rotation gates. `R_XX(alpha) q0 q1` applies `exp(-i * alpha * pi/2 * XX)` (and likewise for `YY`/`ZZ`), while `R_PAULI(alpha) X0*Y1*Z2` applies the rotation for an arbitrary Pauli product (up to 64 qubits per instruction). The `alpha` parameter is in half-turns, matching the existing `R_X`/`R_Y`/`R_Z` convention. Duplicate target qubits are rejected at parse time. (#142)
-- Fast path in the detector sampler for components whose output is deterministically given by a single error variable. These components now skip the JAX compilation and autoregressive sampling pipeline, significantly speeding up detector sampling for surface-code circuits at low physical error rates.
-- `CompiledDetectorSampler.sample` now accepts an optional `postselection_mask` argument for postselected simulations (#41). The mask has length `num_detectors`; a shot is discarded when any masked detector fires. When a discarded shot is flagged by a direct detector, the expensive JAX autoregressive loop is skipped for that draw while still returning one row per requested shot. Discarded rows retain their direct detector columns and fill all other columns with zero; callers recover surviving shots by re-applying the mask to the returned detector columns. Masks that only target non-direct detectors, or that mask no direct detectors, fall back to the standard sampling path. Fully-direct circuits continue to use the NumPy fast path.
+- `CCX` (Toffoli) and `CCZ` gates in circuit text and `Circuit.append`, implemented using Clifford+T decompositions. (#150)
+- `R_XX`, `R_YY`, `R_ZZ`, and `R_PAULI` parametric Pauli-product rotation gates. `R_XX(alpha) q0 q1` applies `exp(-i * alpha * pi/2 * XX)` (and likewise for `YY`/`ZZ`), while `R_PAULI(alpha) X0*Y1*Z2` applies the rotation for an arbitrary Pauli product (up to 64 qubits per instruction). The `alpha` parameter is in half-turns, matching the existing `R_X`/`R_Y`/`R_Z` convention. Duplicate target qubits are rejected at parse time. (#152)
+- Global-rotation quantum error-correction tutorial covering color-code state preparation, noise, postselection, and logical-error analysis. (#156)
+- Fast path in the detector sampler for components whose output is deterministically given by a single error variable. These components now skip the JAX compilation and autoregressive sampling pipeline, significantly speeding up detector sampling for surface-code circuits at low physical error rates. (#78)
+- `CompiledDetectorSampler.sample` now accepts an optional `postselection_mask` argument for postselected simulations. The mask has length `num_detectors`; a shot is discarded when any masked detector fires. When a discarded shot is flagged by a direct detector, the expensive JAX autoregressive loop is skipped for that draw while still returning one row per requested shot. Discarded rows retain their direct detector columns and fill all other columns with zero; callers recover surviving shots by re-applying the mask to the returned detector columns. Masks that only target non-direct detectors, or that mask no direct detectors, fall back to the standard sampling path. Fully-direct circuits continue to use the NumPy fast path. (#157)
 
-
+### Changed
+- Exact-scalar reductions and device-to-host transfers now use lower-memory JAX and CUDA paths, reducing sampling memory use and transfer overhead for large detector-sampling workloads. (#149)
+- `ipywidgets` is now installed as a runtime dependency so notebook circuit diagrams work in clean installations. (#179)
 
 ## [0.1.4] - 2026-04-28
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bloqade-tsim"
-version = "0.2.0-dev"
+version = "0.1.5"
 description = "A low-magic universal quantum circuit sampler based on ZX stabilizer rank decomposition"
 authors = [
     { name = "Rafael Haenel", email = "rhaenel@quera.com" },

--- a/src/tsim/__init__.py
+++ b/src/tsim/__init__.py
@@ -14,7 +14,7 @@ The package is organized as follows:
 - `utils/`: Utility functions for visualization and linear algebra.
 """
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 from tsim.circuit import Circuit as Circuit
 from tsim.sampler import (

--- a/uv.lock
+++ b/uv.lock
@@ -142,7 +142,7 @@ css = [
 
 [[package]]
 name = "bloqade-tsim"
-version = "0.2.0.dev0"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "equinox" },


### PR DESCRIPTION
## Summary

- finalize the package version as 0.1.5 in project metadata, runtime metadata, and the lockfile
- publish the accumulated Unreleased notes as the dated 0.1.5 changelog entry
- add missing release notes for CCX/CCZ, the global-rotation QEC tutorial, sampling performance improvements, and the runtime ipywidgets dependency

## Impact

This is a patch release containing additive APIs, performance improvements, documentation, and packaging fixes. No public breaking changes are included.

## Validation

- `uv run pytest -q`: 1,148 passed
- `uv build`: wheel and source distribution built successfully
- clean Python 3.12 wheel install: resolved and installed 40 runtime packages; version/import/sampling smoke test passed
- clean Python 3.12 source-distribution install: resolved and installed 40 runtime packages; version/import smoke test passed
- clean Python 3.12 install directly from this GitHub branch: resolved and installed 40 runtime packages; version/import/sampling smoke test passed
- focused Pyright check for the changed Python module: passed
- independent release-diff review: no Critical or Important findings