### PR TITLE
feat: add timeline-text diagram type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `"timeline-text"` diagram type. Renders tsim's custom gates under their
+  logical names instead of the Clifford placeholders used to store them, so
+  `T` prints as `T` rather than `S`. Covers `T`, `T_DAG`, `TPP`, `TPP_DAG`,
+  `R_X`, `R_Y`, `R_Z`, and `U3`. `R_XX`, `R_YY`, and `R_ZZ` share `R_PAULI`'s
+  metadata tag and render as `R_PAULI(alpha)`. Rendering is provided by the
+  `stim-timeline-text` package. (#171)
+
 ## [0.1.5] - 2026-07-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ dependencies = [
     "psutil>=5.9.0",
     "pyzx-param>=0.9.3",
     "stim>=1.0.0",
+    "stim-timeline-text>=0.1.0",
+    "stim-timeline-text>=0.1.0",
 ]
 
 [project.urls]

--- a/src/tsim/circuit.py
+++ b/src/tsim/circuit.py
@@ -656,6 +656,7 @@ class Circuit:
             "pyzx-meas",
             "timeline-svg",
             "timeslice-svg",
+            "timeline-text",
         ] = "timeline-svg",
         tick: int | range | None = None,
         filter_coords: Iterable[Iterable[float] | stim.DemTarget] = ((),),
@@ -681,6 +682,10 @@ class Circuit:
                 "timeslice-svg": An SVG image of the operations applied
                     between two TICK instructions in the circuit, with the
                     operations laid out in 2d.
+                "timeline-text": An ASCII text diagram of the operations
+                    applied by the circuit over time, with tsim's custom
+                    gates rendered under their logical names rather than
+                    the Clifford placeholders used to store them.
             tick: Required for time slice diagrams. Specifies
                 which TICK instruction, or range of TICK instructions, to
                 slice at. Note that the first TICK instruction in the
@@ -759,6 +764,10 @@ class Circuit:
                 scale_horizontally(g, kwargs.pop("scale_horizontally", 1.0))
             zx.draw(g, **kwargs)
             return g
+        elif type == "timeline-text":
+            from stim_timeline_text import render_timeline_text
+
+            return render_timeline_text(str(self._stim_circ))
         else:
             return self._stim_circ.diagram(type=type, **kwargs)  # pragma: no cover
 

--- a/test/unit/test_timeline_text.py
+++ b/test/unit/test_timeline_text.py
@@ -1,0 +1,68 @@
+"""Tests for the timeline-text diagram type."""
+
+import pytest
+
+import tsim
+
+
+def render(circuit: tsim.Circuit) -> str:
+    return str(circuit.diagram("timeline-text"))
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ("T 0", "T"),
+        ("T_DAG 0", "T_DAG"),
+        ("R_X(0.125) 0", "R_X(0.125)"),
+        ("R_Y(-0.25) 0", "R_Y(-0.25)"),
+        ("R_Z(0.5) 0", "R_Z(0.5)"),
+        ("U3(0.5,0.25,-0.125) 0", "U3(0.5,0.25,-0.125)"),
+        ("TPP X0*Y1", "TPP[X]"),
+        ("TPP_DAG Z0", "TPP_DAG[Z]"),
+    ],
+)
+def test_custom_gates_render_logical_names(source, expected):
+    assert expected in render(tsim.Circuit(source))
+
+
+def test_t_gate_is_not_rendered_as_placeholder():
+    """Regression test for #171."""
+    out = render(tsim.Circuit("T 0"))
+    assert "T" in out
+    assert "-S-" not in out
+
+
+@pytest.mark.parametrize(
+    "name,arg,expected",
+    [
+        ("R_XX", 0.5, "R_PAULI(0.5)[X]"),
+        ("R_YY", -0.25, "R_PAULI(-0.25)[Y]"),
+        ("R_ZZ", 0.125, "R_PAULI(0.125)[Z]"),
+    ],
+)
+def test_two_qubit_rotations_render_as_r_pauli(name, arg, expected):
+    """R_XX/R_YY/R_ZZ share R_PAULI's metadata tag, so they render as R_PAULI."""
+    circuit = tsim.Circuit()
+    circuit.append(name, [0, 1], arg)
+    assert expected in render(circuit)
+
+
+def test_ccz_shows_its_clifford_t_decomposition():
+    circuit = tsim.Circuit()
+    circuit.append("CCZ", [0, 1, 2])
+    out = render(circuit)
+    assert "T" in out and "T_DAG" in out
+
+
+def test_user_tag_is_stripped_from_label():
+    circuit = tsim.Circuit()
+    circuit.append("T", [0], tag="mynote")
+    out = render(circuit)
+    assert "T" in out
+    assert "mynote" not in out
+
+
+def test_standard_gates_are_unaffected():
+    out = render(tsim.Circuit("H 0\nCX 0 1\nM 0 1"))
+    assert "H" in out and "@" in out

--- a/uv.lock
+++ b/uv.lock
@@ -155,6 +155,7 @@ dependencies = [
     { name = "psutil" },
     { name = "pyzx-param" },
     { name = "stim" },
+    { name = "stim-timeline-text" },
 ]
 
 [package.optional-dependencies]
@@ -221,6 +222,7 @@ requires-dist = [
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pyzx-param", specifier = ">=0.9.3" },
     { name = "stim", specifier = ">=1.0.0" },
+    { name = "stim-timeline-text", specifier = ">=0.1.0" },
 ]
 provides-extras = ["cuda12", "cuda13"]
 
@@ -278,7 +280,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -507,7 +509,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -579,7 +581,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -892,7 +894,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1139,17 +1141,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -1164,17 +1166,17 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version == '3.11.*'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version == '3.11.*'" },
-    { name = "jedi", marker = "python_full_version == '3.11.*'" },
-    { name = "matplotlib-inline", marker = "python_full_version == '3.11.*'" },
-    { name = "pexpect", marker = "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "stack-data", marker = "python_full_version == '3.11.*'" },
-    { name = "traitlets", marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/25/daae0e764047b0a2480c7bbb25d48f4f509b5818636562eeac145d06dfee/ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4", size = 4426663, upload-time = "2026-03-27T09:53:26.244Z" }
 wheels = [
@@ -1190,16 +1192,16 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
 wheels = [
@@ -1211,7 +1213,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1253,11 +1255,11 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "opt-einsum", marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "opt-einsum" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/1e/267f59c8fb7f143c3f778c76cb7ef1389db3fd7e4540f04b9f42ca90764d/jax-0.6.2.tar.gz", hash = "sha256:a437d29038cbc8300334119692744704ca7941490867b9665406b7f90665cd96", size = 2334091, upload-time = "2025-06-17T23:10:27.186Z" }
 wheels = [
@@ -1266,8 +1268,8 @@ wheels = [
 
 [package.optional-dependencies]
 cuda12 = [
-    { name = "jax-cuda12-plugin", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, extra = ["with-cuda"], marker = "python_full_version < '3.11'" },
-    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jax-cuda12-plugin", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, extra = ["with-cuda"] },
+    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [[package]]
@@ -1280,11 +1282,11 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "opt-einsum", marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jaxlib", version = "0.9.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "opt-einsum" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/4c/5aca25abd45fa38dd136e5ae2010376518c67950e1f9408e0c5c93fcf77d/jax-0.9.2.tar.gz", hash = "sha256:42b28017b3e6b57a44b0274cc15f5153239c4873959030399ac1afc009c22365", size = 2662784, upload-time = "2026-03-18T23:28:10.471Z" }
 wheels = [
@@ -1293,12 +1295,12 @@ wheels = [
 
 [package.optional-dependencies]
 cuda12 = [
-    { name = "jax-cuda12-plugin", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, extra = ["with-cuda"], marker = "python_full_version >= '3.11'" },
-    { name = "jaxlib", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jax-cuda12-plugin", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, extra = ["with-cuda"] },
+    { name = "jaxlib", version = "0.9.2", source = { registry = "https://pypi.org/simple" } },
 ]
 cuda13 = [
-    { name = "jax-cuda13-plugin", extra = ["with-cuda"], marker = "python_full_version >= '3.11'" },
-    { name = "jaxlib", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jax-cuda13-plugin", extra = ["with-cuda"] },
+    { name = "jaxlib", version = "0.9.2", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [[package]]
@@ -1335,7 +1337,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "jax-cuda12-pjrt", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jax-cuda12-pjrt", version = "0.6.2", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/29/4b8822ca459da39bda9be7454908ae4e29d88cfb99b480b641cbb063af7a/jax_cuda12_plugin-0.6.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:bc5c3a75d05519b4d326e4669d0f7ad0fe0f0acf875f9313d913748ccca5a9ea", size = 15873729, upload-time = "2025-06-17T23:12:05.046Z" },
@@ -1352,18 +1354,18 @@ wheels = [
 
 [package.optional-dependencies]
 with-cuda = [
-    { name = "nvidia-cublas-cu12", marker = "python_full_version < '3.11'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "python_full_version < '3.11'" },
-    { name = "nvidia-cuda-nvcc-cu12", marker = "python_full_version < '3.11'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "python_full_version < '3.11'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "python_full_version < '3.11'" },
-    { name = "nvidia-cudnn-cu12", marker = "python_full_version < '3.11'" },
-    { name = "nvidia-cufft-cu12", marker = "python_full_version < '3.11'" },
-    { name = "nvidia-cusolver-cu12", marker = "python_full_version < '3.11'" },
-    { name = "nvidia-cusparse-cu12", marker = "python_full_version < '3.11'" },
-    { name = "nvidia-nccl-cu12", marker = "python_full_version < '3.11'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version < '3.11'" },
-    { name = "nvidia-nvshmem-cu12", marker = "python_full_version < '3.11'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cuda-cupti-cu12" },
+    { name = "nvidia-cuda-nvcc-cu12" },
+    { name = "nvidia-cuda-nvrtc-cu12" },
+    { name = "nvidia-cuda-runtime-cu12" },
+    { name = "nvidia-cudnn-cu12" },
+    { name = "nvidia-cufft-cu12" },
+    { name = "nvidia-cusolver-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nccl-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvshmem-cu12" },
 ]
 
 [[package]]
@@ -1376,7 +1378,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "jax-cuda12-pjrt", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jax-cuda12-pjrt", version = "0.9.2", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/de/8294a939e9eddcf6420d568713ca5018167f15f776e125f4205d4ffd8f6f/jax_cuda12_plugin-0.9.2-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:b3955f375d17902f0d27e7059672cd1963a55345953a42699e4e078cec725adc", size = 5652929, upload-time = "2026-03-18T23:26:12.277Z" },
@@ -1395,18 +1397,18 @@ wheels = [
 
 [package.optional-dependencies]
 with-cuda = [
-    { name = "nvidia-cublas-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvcc-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1423,7 +1425,7 @@ name = "jax-cuda13-plugin"
 version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jax-cuda13-pjrt", marker = "python_full_version >= '3.11'" },
+    { name = "jax-cuda13-pjrt" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/dc/157b6cd4badf957c43d913f58676d98dc936d643eff4ac28e030c317f44c/jax_cuda13_plugin-0.9.2-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:f0cda88f70db5877d2bb2f99c456d34e2c904da2a0f783973d4cebdad4ed0c88", size = 5642490, upload-time = "2026-03-18T23:26:37.732Z" },
@@ -1442,19 +1444,19 @@ wheels = [
 
 [package.optional-dependencies]
 with-cuda = [
-    { name = "nvidia-cublas", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvcc", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu13", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
-    { name = "nvidia-nvvm", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvvm" },
 ]
 
 [[package]]
@@ -1465,9 +1467,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/c5/41598634c99cbebba46e6777286fb76abc449d33d50aeae5d36128ca8803/jaxlib-0.6.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4601b2b5dc8c23d6afb293eacfb9aec4e1d1871cb2f29c5a151d103e73b0f8", size = 54298019, upload-time = "2025-06-17T23:10:36.916Z" },
@@ -1500,9 +1502,9 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/2c/0ba08670ab04f6094f0cda4cdc89818946007d0d1dfefa636eab6c7d5392/jaxlib-0.9.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:785f177c3eb78cb7dc797c55ed5c4b6312141845c9a686957e484bacbfce5e88", size = 58762159, upload-time = "2026-03-18T23:26:55.405Z" },
@@ -1537,7 +1539,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "wadler-lindig", marker = "python_full_version < '3.11'" },
+    { name = "wadler-lindig" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/40/a2ea3ce0e3e5f540eb970de7792c90fa58fef1b27d34c83f9fa94fea4729/jaxtyping-0.3.7.tar.gz", hash = "sha256:3bd7d9beb7d3cb01a89f93f90581c6f4fff3e5c5dc3c9307e8f8687a040d10c4", size = 45721, upload-time = "2026-01-30T14:18:47.409Z" }
 wheels = [
@@ -1554,7 +1556,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "wadler-lindig", marker = "python_full_version >= '3.11'" },
+    { name = "wadler-lindig" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/be/00294e369938937e31b094437d5ea040e4fd1a20b998ebe572c4a1dcfa68/jaxtyping-0.3.9.tar.gz", hash = "sha256:f8c02d1b623d5f1b6665d4f3ddaec675d70004f16a792102c2fc51264190951d", size = 45857, upload-time = "2026-02-16T10:35:13.263Z" }
 wheels = [
@@ -2989,9 +2991,9 @@ name = "nvidia-cuda-nvcc"
 version = "13.2.51"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-crt", marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-cuda-runtime", marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-nvvm", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cuda-crt" },
+    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-nvvm" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/d8/3d1d733db86c1f18359151b0be0171b04738f17f09f98658caf9e3b5299d/nvidia_cuda_nvcc-13.2.51-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48e070550a1290d696f055fa78443831bce5452cd2800eb3ab83f89b22c3b6cf", size = 38713648, upload-time = "2026-03-09T09:35:12.217Z" },
@@ -3064,7 +3066,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -3076,7 +3078,7 @@ name = "nvidia-cufft"
 version = "12.2.0.37"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/4d/31158ab042b044b269019574da4430ecce8d05fec7af1d270e1ba28e3512/nvidia_cufft-12.2.0.37-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d0d762b7ece2f2a4971a5f29a6cef13f26fd87c7cd0003b48ed82d9a1d7380d7", size = 218244744, upload-time = "2026-03-09T09:48:16.661Z" },
@@ -3101,9 +3103,9 @@ name = "nvidia-cusolver"
 version = "12.1.0.51"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-cusparse", marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/09/6214d11749dfc2d1be9a9e0bcfb04069077b98f7df0ad41115da87c84700/nvidia_cusolver-12.1.0.51-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:2a0bde343f956934103bc19344584a2d7b95d03b8cca9c0d22c90ff8917bbc3c", size = 224103511, upload-time = "2026-03-09T09:51:14.704Z" },
@@ -3130,7 +3132,7 @@ name = "nvidia-cusparse"
 version = "12.7.9.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/5a/6bb7fc5f9658902efebc8551b1a9265b7a5908cbf9efdabdf97bc30b168a/nvidia_cusparse-12.7.9.17-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7c5d21980dc5f064c7ba13af2250e7fb4036283f1d1943c2915573c27928c89e", size = 168894384, upload-time = "2026-03-09T09:52:23.003Z" },
@@ -3204,7 +3206,7 @@ name = "nvidia-nvshmem-cu13"
 version = "3.6.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-cccl", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cuda-cccl" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/6b/4c642d2cce57c8bd32043b4a608b6acc8cd0579c2f53af9a7ef9e1e1ccca/nvidia_nvshmem_cu13-3.6.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94aa0149490be658cf95945ce9f16ba90a90edbd6a564366f996ead7496f2f22", size = 71726240, upload-time = "2026-03-24T19:19:29.816Z" },
@@ -4091,7 +4093,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -4152,7 +4154,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4289,6 +4291,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/7f/825d745dc128321dd2f41da75d18111121a90e7bb711da24f28b1e003c9e/stim-1.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:673a323402c266b1a1225565d69d31816c3d4a4c259383ed4fa9c15cacd12411", size = 1974528, upload-time = "2025-05-07T06:18:51.125Z" },
     { url = "https://files.pythonhosted.org/packages/bb/99/10604264cd7159573d6d01cdf5f9675c71580dcc3df5c533fccabad59cda/stim-1.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:35e36d0479015b4dcb4261b8b68be85067cbd4bac5632bdfdb3ee3f8671d05a9", size = 1838700, upload-time = "2025-05-07T06:18:52.95Z" },
     { url = "https://files.pythonhosted.org/packages/25/97/1bf3bf16129667eff1c0d0f3bb95262a2bec8c8d1227aa973b8e2a1935b6/stim-1.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb9465ab120837ecbd26b5af216a00715f04da087ddcfa09646892c8de720d09", size = 4967782, upload-time = "2025-05-07T06:18:54.94Z" },
+]
+
+[[package]]
+name = "stim-timeline-text"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/9c/683c8608d0613ddcd80b9d44df01063351fcc1fd24554d9d0fa0ad89b9b7/stim_timeline_text-0.1.0.tar.gz", hash = "sha256:5632775c6ca4fd248075b21aafe70b4cf0e890aa0b146a311f021ee8eecd317a", size = 104129, upload-time = "2026-07-31T06:50:55.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/85/6788008196e75a35c84a151e1fee3f10c4901308482721fb09cf8ab3f1c2/stim_timeline_text-0.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ce8c351c9ea9bfe4b31efd92f211b7db2f57f6559765cd979daf39411d6302dd", size = 114240, upload-time = "2026-07-31T06:50:34.001Z" },
+    { url = "https://files.pythonhosted.org/packages/90/f2/880d40fd9f65e50e8851008d561395c2066b84313c8f0936b14e6cde20cb/stim_timeline_text-0.1.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:1d2bdc6ce398295d7296f26864e122764e0d630163cced8fe6863d7c611f0672", size = 121028, upload-time = "2026-07-31T06:50:35.282Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/d9/816b33bbc9cae41cbf2cb727c3d6d960e4c25d6a7903ac5afb685e1c3a4c/stim_timeline_text-0.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6852955ab665cf5468f061b2b4518ce17c2bf49f105413fe71b35958cdb99321", size = 180899, upload-time = "2026-07-31T06:50:36.317Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/29/fc353c9b8f9c33b4eb37d66bae08d9ce71a089344011c86823d8e0cea740/stim_timeline_text-0.1.0-cp310-cp310-win32.whl", hash = "sha256:17aaec8d29388ed6e7534232170c7b9b606068d2ca4d2fe57b54e0b5d5b9e40f", size = 121530, upload-time = "2026-07-31T06:50:37.432Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d0/a184c6ffc1cc92b8938523bca9f179bb83f1c9d1e652af06b46b21eec84d/stim_timeline_text-0.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:2144a7d3fe5aa55e08cc0a0a8f276096f6b343c4bf20ad7d74f05fd86762fdd3", size = 143070, upload-time = "2026-07-31T06:50:38.437Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/0a/6cc369ab658387cc6c9175e46a1c822906c4afb263b33adb55b59d2aa3ce/stim_timeline_text-0.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfb286acc85b496d0005162c0257aa8f1a6007ceb9c0130bd1bb6f2b6d975db8", size = 116076, upload-time = "2026-07-31T06:50:39.525Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/9b/7f497d8ad79ccf33bf6c8543b07a9ccf4b3cfa9abbd2fe56825d66bc8fb6/stim_timeline_text-0.1.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:b3ff084f11259556e82dc8f7c9d4fd3ea555dc133e5a9727076212221276e229", size = 122670, upload-time = "2026-07-31T06:50:40.562Z" },
+    { url = "https://files.pythonhosted.org/packages/62/07/eb86bbb56b7d55f34827fdfbafd6fc96e80ce155fea178ac620b67b8f3f6/stim_timeline_text-0.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4694523bc93f4ccb9ac4a8f05cad43a88c82f2d0844c9e50d64cc85c5d482448", size = 182668, upload-time = "2026-07-31T06:50:41.709Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5b/f06d317177073566af9e45e531de9b3928769cbbd5251d07441b7111daa6/stim_timeline_text-0.1.0-cp311-cp311-win32.whl", hash = "sha256:e0ca688145def2422cee5acf6eb3eae5c2a44ce85d2369247a88066a79658645", size = 122350, upload-time = "2026-07-31T06:50:42.81Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/18/73b1869cb3a1404936a0e5aacecd66daa8ab6a83c1bf678036113d733c96/stim_timeline_text-0.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:5eb24fafe0b0627e283aaf8b92a263de51a3acce8597a42c4e0d986c9e961d09", size = 144302, upload-time = "2026-07-31T06:50:43.88Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/91/6599cb621277640c7d63a9665a3ee56b9dee629b19408c2ce011a92682dc/stim_timeline_text-0.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9254dc363602f0c9bbf8418d68188df5ed5193fde8350dc485dd942dcb16e0a7", size = 116641, upload-time = "2026-07-31T06:50:44.898Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4c/2c2d664dd9f16226cc44a82f06dfdc1c190c3875ce7e28218b6e5e697b2f/stim_timeline_text-0.1.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:4646fe504daaadcfead790ed554e4a0d0d73a367e2a49939ac37f8abfeee5b78", size = 123330, upload-time = "2026-07-31T06:50:46.086Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2f/44ddf0cf486d1eb729f4c15387e1e58042c62b52fd5daf7252c21aa643da/stim_timeline_text-0.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75766c74733ffc73e0bc6498a322dd5de416f9cb8799dae7ddd7f9ec61007c09", size = 183128, upload-time = "2026-07-31T06:50:47.139Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/e8/ffa40450e63375808fee6ac2ab07b129d17f5d4e452178b15ac2e0d5d7e7/stim_timeline_text-0.1.0-cp312-cp312-win32.whl", hash = "sha256:fa24f6b68e65a585bb58f22754bcbdf84fac5fa19ec33b527c3a521e80576efa", size = 122856, upload-time = "2026-07-31T06:50:48.286Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/fedf6f38558e6ae53bdad9cf832af4802810df2f228913a52f7c15741bba/stim_timeline_text-0.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:152ddb621055da58db038fa0bd3f1f5afe25b3cf5936f8215d45d0eb6751fbab", size = 145491, upload-time = "2026-07-31T06:50:49.521Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/05/b9e55b7a1110de676a3eaa12e711475f5e70a4e58dd5dab3200c01f62315/stim_timeline_text-0.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9dd8dce3d255d4c9fd4a756dd437df25961dafe32635b8a4b7af492ac3387e4c", size = 116656, upload-time = "2026-07-31T06:50:50.661Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/29/fc1448607540bafeb804e772b4b86a6392c966535fa63751d8802064cdd0/stim_timeline_text-0.1.0-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:52bd605185459d6e2552415060add8d632533641163e44299331679c5a1ec7e8", size = 123372, upload-time = "2026-07-31T06:50:51.732Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/55/f7e2bafbb5a26788877b5c1757b5b9a42563ebfb7e3746456318d527df4d/stim_timeline_text-0.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60b0e9f5a8695a6d91420095073faf6013cd78b9ec2352c13864208ce63184b0", size = 183085, upload-time = "2026-07-31T06:50:52.762Z" },
+    { url = "https://files.pythonhosted.org/packages/02/eb/e2071e25fd54de8420827bcf72a030c1db6686c7f1a9443242e1dd607ea9/stim_timeline_text-0.1.0-cp313-cp313-win32.whl", hash = "sha256:5557b1f2529dc2fa41495949376fa64e11a6b87b48c09fc5989e050cc8ecab24", size = 122897, upload-time = "2026-07-31T06:50:53.934Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/21/8d9750ba459fb51bb8f1612c54d63637da828606d59258deb81ab0e723b9/stim_timeline_text-0.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:2e5a6d3f5124e07cf5ebb510be5edddecc22e205f83e38eff4e9e074374cdd1f", size = 145551, upload-time = "2026-07-31T06:50:54.937Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Tsim stores non-Clifford gates as tagged Clifford placeholders, so `T 0` is stored as `S[T] 0`. Stim's timeline drawer discards the tag before building the label, so `Circuit("T 0").diagram("timeline-text")` printed `q0: -S-`. `"timeline-text"` was also not a listed diagram type and fell through to `stim.Circuit.diagram` unchanged.

## Change

Adds `"timeline-text"` as a supported diagram type, routed to [`stim-timeline-text`](https://github.com/shalini9894/stim-timeline-text). That package vendors a pinned subset of Stim v1.15.0's C++ timeline renderer and resolves the metadata tag before ASCII layout, so column widths and connectors account for the longer labels.

| Circuit | Before | After |
|---|---|---|
| `T 0` | `q0: -S-` | `q0: -T-` |
| `R_Z(0.5) 0` | `q0: -I-` | `q0: -R_Z(0.5)-` |
| `TPP X0*Y1` | `q0: -SPP[X]-` | `q0: -TPP[X]-` |

Covers `T`, `T_DAG`, `TPP`, `TPP_DAG`, `R_X`, `R_Y`, `R_Z`, and `U3`.

## Notes

- `R_XX`, `R_YY`, and `R_ZZ` share `R_PAULI`'s metadata tag, so they render as `R_PAULI(alpha)`, per the discussion in #171.
- `CCZ` and `CCX` show their existing Clifford+T decompositions. No synthetic box is added.
- Circuits without tsim metadata render byte-identically to upstream Stim. The package's test suite checks this against 500 generated circuits plus curated cases.
- Adds one dependency: `stim-timeline-text>=0.1.0` (Apache-2.0, wheels for Linux, macOS, and Windows on CPython 3.10-3.13).

## Tests

`test/unit/test_timeline_text.py` covers each custom gate, the `R_PAULI` behaviour, the `CCZ` decomposition, user tag stripping, and that standard gates are unaffected.

Addresses #171